### PR TITLE
fix(readme): fixed typo in usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ npm install @dashevo/dapi-grpc
 ## Usage
 
 ```js
-import { TransactionsFilterStreamPromiseClient, BloomFilter } from '@dashevo/dapi-grpc';
+import { TransactionsFilterStreamClient, BloomFilter } from '@dashevo/dapi-grpc';
 
-const client = new TransactionsFilterStreamPromiseClient('http://localhost:8080');
+const client = new TransactionsFilterStreamClient('http://localhost:8080');
 
 const filter = new BloomFilter();
 filter.setBytes('...');


### PR DESCRIPTION
### Issue being fixed or implemented
Small typo in the readme

### What was done

- docs(readme): fix typo (TransactionsFilterStreamPromiseClient -> TransactionsFilterStreamClient)

### Notes
N/A