### PR TITLE
fix: namespacing of the `platform` service in the build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dapi-grpc",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dapi-grpc",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "DAPI GRPC definition file and generated clients",
   "browser": "browser.js",
   "main": "node.js",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -59,7 +59,7 @@ $PWD/node_modules/protobufjs/bin/pbjs \
 $PWD/node_modules/protobufjs/bin/pbjs \
   -t static-module \
   -w commonjs \
-  -r core_root \
+  -r platform_root \
   -o "$CLIENTS_PATH/nodejs/platform_pbjs.js" \
   "$PROTO_PATH/platform.proto"
 


### PR DESCRIPTION
This was the bug that stopped `core` service from working, as `platform` service compiled module was shadowing `$root` of the `core` services in the same node process.