### PR TITLE
build: only access npm token when deploying

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ addons:
     packages:
       - docker-ce
 
-before_install:
+before_deploy:
   # Add token for @dashevo private npm registry
   - echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,6 @@ addons:
     packages:
       - docker-ce
 
-before_deploy:
-  # Add token for @dashevo private npm registry
-  - echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
-
 install: npm ci
 
 before_script: npm run build
@@ -33,6 +29,10 @@ script:
   - npm run lint
   - npm run test
   - npm run check-package
+
+before_deploy:
+  # Add token for @dashevo private npm registry
+  - echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
 
 deploy:
   provider: script


### PR DESCRIPTION
Currently PRs from external repos cannot successfully run tests because Travis prevents them from accessing the NPM token. This attempts to fix that by bypassing token access unless actually deploying.