### PR TITLE
chore: gRPC version bump

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ addons:
     packages:
       - docker-ce
 
-before_install:
+before_deploy:
   # Add token for @dashevo private npm registry
   - echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,6 @@ addons:
     packages:
       - docker-ce
 
-before_deploy:
-  # Add token for @dashevo private npm registry
-  - echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
-
 install: npm ci
 
 before_script: npm run build
@@ -33,6 +29,10 @@ script:
   - npm run lint
   - npm run test
   - npm run check-package
+
+before_deploy:
+  # Add token for @dashevo private npm registry
+  - echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
 
 deploy:
   provider: script

--- a/package-lock.json
+++ b/package-lock.json
@@ -142,6 +142,15 @@
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
     },
+    "@types/bytebuffer": {
+      "version": "5.0.41",
+      "resolved": "https://registry.npmjs.org/@types/bytebuffer/-/bytebuffer-5.0.41.tgz",
+      "integrity": "sha512-Mdrv4YcaHvpkx25ksqqFaezktx3yZRcd51GZY0rY/9avyaqZdiT/GiWRhfrJhMpgzXqTOSHgGvsumGxJFNiZZA==",
+      "requires": {
+        "@types/long": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/long": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.0.tgz",
@@ -922,14 +931,15 @@
       "dev": true
     },
     "grpc": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.24.0.tgz",
-      "integrity": "sha512-zq1rUh2uzfMqSfQ3bZvlQuX5yKfd/2vob+l9sK5Qma6P33m7UvyMCVW70+Wz0WTzy9W2A94eQD5XIOxKnZhsYQ==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.24.2.tgz",
+      "integrity": "sha512-EG3WH6AWMVvAiV15d+lr+K77HJ/KV/3FvMpjKjulXHbTwgDZkhkcWbwhxFAoTdxTkQvy0WFcO3Nog50QBbHZWw==",
       "requires": {
+        "@types/bytebuffer": "^5.0.40",
         "lodash.camelcase": "^4.3.0",
         "lodash.clone": "^4.5.0",
         "nan": "^2.13.2",
-        "node-pre-gyp": "^0.13.0",
+        "node-pre-gyp": "^0.14.0",
         "protobufjs": "^5.0.3"
       },
       "dependencies": {
@@ -966,7 +976,7 @@
           }
         },
         "chownr": {
-          "version": "1.1.2",
+          "version": "1.1.3",
           "bundled": true
         },
         "code-point-at": {
@@ -1005,10 +1015,10 @@
           "bundled": true
         },
         "fs-minipass": {
-          "version": "1.2.6",
+          "version": "1.2.7",
           "bundled": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.6.0"
           }
         },
         "fs.realpath": {
@@ -1053,7 +1063,7 @@
           }
         },
         "ignore-walk": {
-          "version": "3.0.1",
+          "version": "3.0.3",
           "bundled": true,
           "requires": {
             "minimatch": "^3.0.4"
@@ -1098,7 +1108,7 @@
           "bundled": true
         },
         "minipass": {
-          "version": "2.3.5",
+          "version": "2.9.0",
           "bundled": true,
           "requires": {
             "safe-buffer": "^5.1.2",
@@ -1106,10 +1116,10 @@
           }
         },
         "minizlib": {
-          "version": "1.2.1",
+          "version": "1.3.3",
           "bundled": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "^2.9.0"
           }
         },
         "mkdirp": {
@@ -1139,7 +1149,7 @@
           }
         },
         "node-pre-gyp": {
-          "version": "0.13.0",
+          "version": "0.14.0",
           "bundled": true,
           "requires": {
             "detect-libc": "^1.0.2",
@@ -1151,7 +1161,7 @@
             "rc": "^1.2.7",
             "rimraf": "^2.6.1",
             "semver": "^5.3.0",
-            "tar": "^4"
+            "tar": "^4.4.2"
           }
         },
         "nopt": {
@@ -1167,7 +1177,7 @@
           "bundled": true
         },
         "npm-packlist": {
-          "version": "1.4.4",
+          "version": "1.4.6",
           "bundled": true,
           "requires": {
             "ignore-walk": "^3.0.1",
@@ -1316,12 +1326,12 @@
           "bundled": true
         },
         "tar": {
-          "version": "4.4.10",
+          "version": "4.4.13",
           "bundled": true,
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
-            "minipass": "^2.3.5",
+            "minipass": "^2.8.6",
             "minizlib": "^1.2.1",
             "mkdirp": "^0.5.0",
             "safe-buffer": "^5.1.2",
@@ -1344,7 +1354,7 @@
           "bundled": true
         },
         "yallist": {
-          "version": "3.0.3",
+          "version": "3.1.1",
           "bundled": true
         }
       }
@@ -1947,9 +1957,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
     },
     "natural-compare": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "dependencies": {
     "@dashevo/grpc-common": "^0.2.0",
     "google-protobuf": "^3.8.0",
-    "grpc": "^1.24.0",
+    "grpc": "^1.24.2",
     "grpc-web": "^1.0.6",
     "protobufjs": "^6.8.8"
   },


### PR DESCRIPTION
Install of grpc 1.24.0 is failing in Travis on node 12.16.3. Related issue on the grpc-node repo: [1402](https://github.com/grpc/grpc-node/issues/1402).