### PR TITLE
feat: use protocol version interceptor in clients

### DIFF
--- a/clients/nodejs/CorePromiseClient.js
+++ b/clients/nodejs/CorePromiseClient.js
@@ -9,7 +9,7 @@ const {
   client: {
     interceptors: {
       jsonToProtobufInterceptorFactory,
-      addMetadataInterceptor,
+      addVersionInterceptorFactory,
     },
     converters: {
       jsonToProtobufFactory,
@@ -56,104 +56,17 @@ const getCoreDefinition = require('../../lib/getCoreDefinition');
 
 const CoreNodeJSClient = getCoreDefinition();
 
-const getStatusOptions = {
-  interceptors: [
-    addMetadataInterceptor,
-    jsonToProtobufInterceptorFactory(
-      jsonToProtobufFactory(
-        ProtocGetStatusResponse,
-        PBJSGetStatusResponse,
-      ),
-      protobufToJsonFactory(
-        PBJSGetStatusRequest,
-      ),
-    ),
-  ],
-};
-
-const getBlockOptions = {
-  interceptors: [
-    addMetadataInterceptor,
-    jsonToProtobufInterceptorFactory(
-      jsonToProtobufFactory(
-        ProtocGetBlockResponse,
-        PBJSGetBlockResponse,
-      ),
-      protobufToJsonFactory(
-        PBJSGetBlockRequest,
-      ),
-    ),
-  ],
-};
-
-const sendTransactionOptions = {
-  interceptors: [
-    addMetadataInterceptor,
-    jsonToProtobufInterceptorFactory(
-      jsonToProtobufFactory(
-        ProtocSendTransactionResponse,
-        PBJSSendTransactionResponse,
-      ),
-      protobufToJsonFactory(
-        PBJSSendTransactionRequest,
-      ),
-    ),
-  ],
-};
-
-const getTransactionOptions = {
-  interceptors: [
-    addMetadataInterceptor,
-    jsonToProtobufInterceptorFactory(
-      jsonToProtobufFactory(
-        ProtocGetTransactionResponse,
-        PBJSGetTransactionResponse,
-      ),
-      protobufToJsonFactory(
-        PBJSGetTransactionRequest,
-      ),
-    ),
-  ],
-};
-
-const getEstimatedTransactionFeeOptions = {
-  interceptors: [
-    addMetadataInterceptor,
-    jsonToProtobufInterceptorFactory(
-      jsonToProtobufFactory(
-        ProtocGetEstimatedTransactionFeeResponse,
-        PBJSGetEstimatedTransactionFeeResponse,
-      ),
-      protobufToJsonFactory(
-        PBJSGetEstimatedTransactionFeeRequest,
-      ),
-    ),
-  ],
-};
-
-const subscribeToBlockHeadersWithChainLocksOptions = {
-  interceptors: [
-    addMetadataInterceptor,
-    jsonToProtobufInterceptorFactory(
-      jsonToProtobufFactory(
-        ProtocBlockHeadersWithChainLocksResponse,
-        PBJSBlockHeadersWithChainLocksResponse,
-      ),
-      protobufToJsonFactory(
-        PBJSBlockHeadersWithChainLocksRequest,
-      ),
-    ),
-  ],
-};
-
 class CorePromiseClient {
   /**
    * @param {string} hostname
+   * @param {string} version
    * @param {?Object} credentials
    * @param {?Object} options
    */
-  constructor(hostname, credentials = grpc.credentials.createInsecure(), options = {}) {
+  constructor(hostname, version, credentials = grpc.credentials.createInsecure(), options = {}) {
     this.client = new CoreNodeJSClient(hostname, credentials, options);
+
+    this.addVersionInterceptor = addVersionInterceptorFactory(version);
 
     this.client.getStatus = promisify(
       this.client.getStatus.bind(this.client),
@@ -189,7 +102,20 @@ class CorePromiseClient {
     return this.client.getStatus(
       getStatusRequest,
       convertObjectToMetadata(metadata),
-      getStatusOptions,
+      {
+        interceptors: [
+          this.addVersionInterceptor,
+          jsonToProtobufInterceptorFactory(
+            jsonToProtobufFactory(
+              ProtocGetStatusResponse,
+              PBJSGetStatusResponse,
+            ),
+            protobufToJsonFactory(
+              PBJSGetStatusRequest,
+            ),
+          ),
+        ],
+      },
     );
   }
 
@@ -206,7 +132,20 @@ class CorePromiseClient {
     return this.client.getBlock(
       getBlockRequest,
       convertObjectToMetadata(metadata),
-      getBlockOptions,
+      {
+        interceptors: [
+          this.addVersionInterceptor,
+          jsonToProtobufInterceptorFactory(
+            jsonToProtobufFactory(
+              ProtocGetBlockResponse,
+              PBJSGetBlockResponse,
+            ),
+            protobufToJsonFactory(
+              PBJSGetBlockRequest,
+            ),
+          ),
+        ],
+      },
     );
   }
 
@@ -223,7 +162,20 @@ class CorePromiseClient {
     return this.client.sendTransaction(
       sendTransactionRequest,
       convertObjectToMetadata(metadata),
-      sendTransactionOptions,
+      {
+        interceptors: [
+          this.addVersionInterceptor,
+          jsonToProtobufInterceptorFactory(
+            jsonToProtobufFactory(
+              ProtocSendTransactionResponse,
+              PBJSSendTransactionResponse,
+            ),
+            protobufToJsonFactory(
+              PBJSSendTransactionRequest,
+            ),
+          ),
+        ],
+      },
     );
   }
 
@@ -240,7 +192,20 @@ class CorePromiseClient {
     return this.client.getTransaction(
       getTransactionRequest,
       convertObjectToMetadata(metadata),
-      getTransactionOptions,
+      {
+        interceptors: [
+          this.addVersionInterceptor,
+          jsonToProtobufInterceptorFactory(
+            jsonToProtobufFactory(
+              ProtocGetTransactionResponse,
+              PBJSGetTransactionResponse,
+            ),
+            protobufToJsonFactory(
+              PBJSGetTransactionRequest,
+            ),
+          ),
+        ],
+      },
     );
   }
 
@@ -257,7 +222,20 @@ class CorePromiseClient {
     return this.client.getEstimatedTransactionFee(
       getEstimatedTransactionFeeRequest,
       convertObjectToMetadata(metadata),
-      getEstimatedTransactionFeeOptions,
+      {
+        interceptors: [
+          this.addVersionInterceptor,
+          jsonToProtobufInterceptorFactory(
+            jsonToProtobufFactory(
+              ProtocGetEstimatedTransactionFeeResponse,
+              PBJSGetEstimatedTransactionFeeResponse,
+            ),
+            protobufToJsonFactory(
+              PBJSGetEstimatedTransactionFeeRequest,
+            ),
+          ),
+        ],
+      },
     );
   }
 
@@ -275,7 +253,20 @@ class CorePromiseClient {
     return this.client.subscribeToBlockHeadersWithChainLocks(
       blockHeadersWithChainLocksRequest,
       convertObjectToMetadata(metadata),
-      subscribeToBlockHeadersWithChainLocksOptions,
+      {
+        interceptors: [
+          this.addVersionInterceptor,
+          jsonToProtobufsubscribeToBlockHeadersWithChainLocksOptionsInterceptorFactory(
+            jsonToProtobufFactory(
+              ProtocBlockHeadersWithChainLocksResponse,
+              PBJSBlockHeadersWithChainLocksResponse,
+            ),
+            protobufToJsonFactory(
+              PBJSBlockHeadersWithChainLocksRequest,
+            ),
+          ),
+        ],
+      },
     );
   }
 }

--- a/clients/nodejs/CorePromiseClient.js
+++ b/clients/nodejs/CorePromiseClient.js
@@ -9,7 +9,7 @@ const {
   client: {
     interceptors: {
       jsonToProtobufInterceptorFactory,
-      addVersionInterceptorFactory,
+      protocolVersionInterceptorFactory,
     },
     converters: {
       jsonToProtobufFactory,
@@ -103,7 +103,7 @@ class CorePromiseClient {
       convertObjectToMetadata(metadata),
       {
         interceptors: [
-          addVersionInterceptorFactory(
+          protocolVersionInterceptorFactory(
             this.protocolVersion,
           ),
           jsonToProtobufInterceptorFactory(
@@ -135,7 +135,7 @@ class CorePromiseClient {
       convertObjectToMetadata(metadata),
       {
         interceptors: [
-          addVersionInterceptorFactory(
+          protocolVersionInterceptorFactory(
             this.protocolVersion,
           ),
           jsonToProtobufInterceptorFactory(
@@ -167,7 +167,7 @@ class CorePromiseClient {
       convertObjectToMetadata(metadata),
       {
         interceptors: [
-          addVersionInterceptorFactory(
+          protocolVersionInterceptorFactory(
             this.protocolVersion,
           ),
           jsonToProtobufInterceptorFactory(
@@ -199,7 +199,7 @@ class CorePromiseClient {
       convertObjectToMetadata(metadata),
       {
         interceptors: [
-          addVersionInterceptorFactory(
+          protocolVersionInterceptorFactory(
             this.protocolVersion,
           ),
           jsonToProtobufInterceptorFactory(
@@ -231,7 +231,7 @@ class CorePromiseClient {
       convertObjectToMetadata(metadata),
       {
         interceptors: [
-          addVersionInterceptorFactory(
+          protocolVersionInterceptorFactory(
             this.protocolVersion,
           ),
           jsonToProtobufInterceptorFactory(
@@ -264,7 +264,7 @@ class CorePromiseClient {
       convertObjectToMetadata(metadata),
       {
         interceptors: [
-          addVersionInterceptorFactory(
+          protocolVersionInterceptorFactory(
             this.protocolVersion,
           ),
           jsonToProtobufInterceptorFactory(

--- a/clients/nodejs/CorePromiseClient.js
+++ b/clients/nodejs/CorePromiseClient.js
@@ -59,14 +59,11 @@ const CoreNodeJSClient = getCoreDefinition();
 class CorePromiseClient {
   /**
    * @param {string} hostname
-   * @param {string} version
    * @param {?Object} credentials
    * @param {?Object} options
    */
-  constructor(hostname, version, credentials = grpc.credentials.createInsecure(), options = {}) {
+  constructor(hostname, credentials = grpc.credentials.createInsecure(), options = {}) {
     this.client = new CoreNodeJSClient(hostname, credentials, options);
-
-    this.addVersionInterceptor = addVersionInterceptorFactory(version);
 
     this.client.getStatus = promisify(
       this.client.getStatus.bind(this.client),
@@ -87,6 +84,8 @@ class CorePromiseClient {
     this.client.getEstimatedTransactionFee = promisify(
       this.client.getEstimatedTransactionFee.bind(this.client),
     );
+
+    this.protocolVersion = undefined;
   }
 
   /**
@@ -104,7 +103,9 @@ class CorePromiseClient {
       convertObjectToMetadata(metadata),
       {
         interceptors: [
-          this.addVersionInterceptor,
+          addVersionInterceptorFactory(
+            this.protocolVersion,
+          ),
           jsonToProtobufInterceptorFactory(
             jsonToProtobufFactory(
               ProtocGetStatusResponse,
@@ -134,7 +135,9 @@ class CorePromiseClient {
       convertObjectToMetadata(metadata),
       {
         interceptors: [
-          this.addVersionInterceptor,
+          addVersionInterceptorFactory(
+            this.protocolVersion,
+          ),
           jsonToProtobufInterceptorFactory(
             jsonToProtobufFactory(
               ProtocGetBlockResponse,
@@ -164,7 +167,9 @@ class CorePromiseClient {
       convertObjectToMetadata(metadata),
       {
         interceptors: [
-          this.addVersionInterceptor,
+          addVersionInterceptorFactory(
+            this.protocolVersion,
+          ),
           jsonToProtobufInterceptorFactory(
             jsonToProtobufFactory(
               ProtocSendTransactionResponse,
@@ -194,7 +199,9 @@ class CorePromiseClient {
       convertObjectToMetadata(metadata),
       {
         interceptors: [
-          this.addVersionInterceptor,
+          addVersionInterceptorFactory(
+            this.protocolVersion,
+          ),
           jsonToProtobufInterceptorFactory(
             jsonToProtobufFactory(
               ProtocGetTransactionResponse,
@@ -224,7 +231,9 @@ class CorePromiseClient {
       convertObjectToMetadata(metadata),
       {
         interceptors: [
-          this.addVersionInterceptor,
+          addVersionInterceptorFactory(
+            this.protocolVersion,
+          ),
           jsonToProtobufInterceptorFactory(
             jsonToProtobufFactory(
               ProtocGetEstimatedTransactionFeeResponse,
@@ -255,7 +264,9 @@ class CorePromiseClient {
       convertObjectToMetadata(metadata),
       {
         interceptors: [
-          this.addVersionInterceptor,
+          addVersionInterceptorFactory(
+            this.protocolVersion,
+          ),
           jsonToProtobufInterceptorFactory(
             jsonToProtobufFactory(
               ProtocBlockHeadersWithChainLocksResponse,
@@ -268,6 +279,13 @@ class CorePromiseClient {
         ],
       },
     );
+  }
+
+  /**
+   * @param {string} protocolVersion
+   */
+  setProtocolVersion(protocolVersion) {
+    this.setProtocolVersion = protocolVersion;
   }
 }
 

--- a/clients/nodejs/CorePromiseClient.js
+++ b/clients/nodejs/CorePromiseClient.js
@@ -9,6 +9,7 @@ const {
   client: {
     interceptors: {
       jsonToProtobufInterceptorFactory,
+      addMetadataInterceptor,
     },
     converters: {
       jsonToProtobufFactory,
@@ -57,6 +58,7 @@ const CoreNodeJSClient = getCoreDefinition();
 
 const getStatusOptions = {
   interceptors: [
+    addMetadataInterceptor,
     jsonToProtobufInterceptorFactory(
       jsonToProtobufFactory(
         ProtocGetStatusResponse,
@@ -71,6 +73,7 @@ const getStatusOptions = {
 
 const getBlockOptions = {
   interceptors: [
+    addMetadataInterceptor,
     jsonToProtobufInterceptorFactory(
       jsonToProtobufFactory(
         ProtocGetBlockResponse,
@@ -85,6 +88,7 @@ const getBlockOptions = {
 
 const sendTransactionOptions = {
   interceptors: [
+    addMetadataInterceptor,
     jsonToProtobufInterceptorFactory(
       jsonToProtobufFactory(
         ProtocSendTransactionResponse,
@@ -99,6 +103,7 @@ const sendTransactionOptions = {
 
 const getTransactionOptions = {
   interceptors: [
+    addMetadataInterceptor,
     jsonToProtobufInterceptorFactory(
       jsonToProtobufFactory(
         ProtocGetTransactionResponse,
@@ -113,6 +118,7 @@ const getTransactionOptions = {
 
 const getEstimatedTransactionFeeOptions = {
   interceptors: [
+    addMetadataInterceptor,
     jsonToProtobufInterceptorFactory(
       jsonToProtobufFactory(
         ProtocGetEstimatedTransactionFeeResponse,
@@ -127,6 +133,7 @@ const getEstimatedTransactionFeeOptions = {
 
 const subscribeToBlockHeadersWithChainLocksOptions = {
   interceptors: [
+    addMetadataInterceptor,
     jsonToProtobufInterceptorFactory(
       jsonToProtobufFactory(
         ProtocBlockHeadersWithChainLocksResponse,

--- a/clients/nodejs/CorePromiseClient.js
+++ b/clients/nodejs/CorePromiseClient.js
@@ -256,7 +256,7 @@ class CorePromiseClient {
       {
         interceptors: [
           this.addVersionInterceptor,
-          jsonToProtobufsubscribeToBlockHeadersWithChainLocksOptionsInterceptorFactory(
+          jsonToProtobufInterceptorFactory(
             jsonToProtobufFactory(
               ProtocBlockHeadersWithChainLocksResponse,
               PBJSBlockHeadersWithChainLocksResponse,

--- a/clients/nodejs/PlatformPromiseClient.js
+++ b/clients/nodejs/PlatformPromiseClient.js
@@ -9,7 +9,7 @@ const {
   client: {
     interceptors: {
       jsonToProtobufInterceptorFactory,
-      addMetadataInterceptor,
+      addVersionInterceptorFactory,
     },
     converters: {
       jsonToProtobufFactory,
@@ -50,74 +50,17 @@ const getPlatformDefinition = require('../../lib/getPlatformDefinition');
 
 const PlatformNodeJSClient = getPlatformDefinition();
 
-const applyStateTransitionOptions = {
-  interceptors: [
-    addMetadataInterceptor,
-    jsonToProtobufInterceptorFactory(
-      jsonToProtobufFactory(
-        ProtocApplyStateTransitionResponse,
-        PBJSApplyStateTransitionResponse,
-      ),
-      protobufToJsonFactory(
-        PBJSApplyStateTransitionRequest,
-      ),
-    ),
-  ],
-};
-
-const getIdentityOptions = {
-  interceptors: [
-    addMetadataInterceptor,
-    jsonToProtobufInterceptorFactory(
-      jsonToProtobufFactory(
-        ProtocGetIdentityResponse,
-        PBJSGetIdentityResponse,
-      ),
-      protobufToJsonFactory(
-        PBJSGetIdentityRequest,
-      ),
-    ),
-  ],
-};
-
-const getDataContractOptions = {
-  interceptors: [
-    addMetadataInterceptor,
-    jsonToProtobufInterceptorFactory(
-      jsonToProtobufFactory(
-        ProtocGetDataContractResponse,
-        PBJSGetDataContractResponse,
-      ),
-      protobufToJsonFactory(
-        PBJSGetDataContractRequest,
-      ),
-    ),
-  ],
-};
-
-const getDocumentsOptions = {
-  interceptors: [
-    addMetadataInterceptor,
-    jsonToProtobufInterceptorFactory(
-      jsonToProtobufFactory(
-        ProtocGetDocumentsRequest,
-        PBJSGetDocumentsResponse,
-      ),
-      protobufToJsonFactory(
-        PBJSGetDocumentsRequest,
-      ),
-    ),
-  ],
-};
-
 class PlatformPromiseClient {
   /**
    * @param {string} hostname
+   * @param {string} version
    * @param {?Object} credentials
    * @param {?Object} options
    */
-  constructor(hostname, credentials = grpc.credentials.createInsecure(), options = {}) {
+  constructor(hostname, version, credentials = grpc.credentials.createInsecure(), options = {}) {
     this.client = new PlatformNodeJSClient(hostname, credentials, options);
+
+    this.addVersionInterceptor = addVersionInterceptorFactory(version);
 
     this.client.applyStateTransition = promisify(
       this.client.applyStateTransition.bind(this.client),
@@ -149,7 +92,20 @@ class PlatformPromiseClient {
     return this.client.applyStateTransition(
       applyStateTransitionRequest,
       convertObjectToMetadata(metadata),
-      applyStateTransitionOptions,
+      {
+        interceptors: [
+          this.addVersionInterceptor,
+          jsonToProtobufInterceptorFactory(
+            jsonToProtobufFactory(
+              ProtocApplyStateTransitionResponse,
+              PBJSApplyStateTransitionResponse,
+            ),
+            protobufToJsonFactory(
+              PBJSApplyStateTransitionRequest,
+            ),
+          ),
+        ],
+      },
     );
   }
 
@@ -166,7 +122,20 @@ class PlatformPromiseClient {
     return this.client.getIdentity(
       getIdentityRequest,
       convertObjectToMetadata(metadata),
-      getIdentityOptions,
+      {
+        interceptors: [
+          this.addVersionInterceptor,
+          jsonToProtobufInterceptorFactory(
+            jsonToProtobufFactory(
+              ProtocGetIdentityResponse,
+              PBJSGetIdentityResponse,
+            ),
+            protobufToJsonFactory(
+              PBJSGetIdentityRequest,
+            ),
+          ),
+        ],
+      },
     );
   }
 
@@ -184,7 +153,20 @@ class PlatformPromiseClient {
     return this.client.getDataContract(
       getDataContractRequest,
       convertObjectToMetadata(metadata),
-      getDataContractOptions,
+      {
+        interceptors: [
+          this.addVersionInterceptor,
+          jsonToProtobufInterceptorFactory(
+            jsonToProtobufFactory(
+              ProtocGetDataContractResponse,
+              PBJSGetDataContractResponse,
+            ),
+            protobufToJsonFactory(
+              PBJSGetDataContractRequest,
+            ),
+          ),
+        ],
+      },
     );
   }
 
@@ -202,7 +184,20 @@ class PlatformPromiseClient {
     return this.client.getDocuments(
       getDocumentsRequest,
       convertObjectToMetadata(metadata),
-      getDocumentsOptions,
+      {
+        interceptors: [
+          this.addVersionInterceptor,
+          jsonToProtobufInterceptorFactory(
+            jsonToProtobufFactory(
+              ProtocGetDocumentsRequest,
+              PBJSGetDocumentsResponse,
+            ),
+            protobufToJsonFactory(
+              PBJSGetDocumentsRequest,
+            ),
+          ),
+        ],
+      },
     );
   }
 }

--- a/clients/nodejs/PlatformPromiseClient.js
+++ b/clients/nodejs/PlatformPromiseClient.js
@@ -9,6 +9,7 @@ const {
   client: {
     interceptors: {
       jsonToProtobufInterceptorFactory,
+      addMetadataInterceptor,
     },
     converters: {
       jsonToProtobufFactory,
@@ -51,6 +52,7 @@ const PlatformNodeJSClient = getPlatformDefinition();
 
 const applyStateTransitionOptions = {
   interceptors: [
+    addMetadataInterceptor,
     jsonToProtobufInterceptorFactory(
       jsonToProtobufFactory(
         ProtocApplyStateTransitionResponse,
@@ -65,6 +67,7 @@ const applyStateTransitionOptions = {
 
 const getIdentityOptions = {
   interceptors: [
+    addMetadataInterceptor,
     jsonToProtobufInterceptorFactory(
       jsonToProtobufFactory(
         ProtocGetIdentityResponse,
@@ -79,6 +82,7 @@ const getIdentityOptions = {
 
 const getDataContractOptions = {
   interceptors: [
+    addMetadataInterceptor,
     jsonToProtobufInterceptorFactory(
       jsonToProtobufFactory(
         ProtocGetDataContractResponse,
@@ -93,6 +97,7 @@ const getDataContractOptions = {
 
 const getDocumentsOptions = {
   interceptors: [
+    addMetadataInterceptor,
     jsonToProtobufInterceptorFactory(
       jsonToProtobufFactory(
         ProtocGetDocumentsRequest,

--- a/clients/nodejs/TransactionsFilterStreamPromiseClient.js
+++ b/clients/nodejs/TransactionsFilterStreamPromiseClient.js
@@ -7,6 +7,7 @@ const {
   },
   client: {
     interceptors: {
+      addMetadataInterceptor,
       jsonToProtobufInterceptorFactory,
     },
     converters: {
@@ -43,6 +44,7 @@ const TransactionsFilterStreamNodeJSClient = getTransactionsFilterStreamDefiniti
 
 const subscribeToTransactionsWithProofsOptions = {
   interceptors: [
+    addMetadataInterceptor,
     jsonToProtobufInterceptorFactory(
       jsonToProtobufFactory(
         ProtocTransactionsWithProofsResponse,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dapi-grpc",
-  "version": "0.12.1",
+  "version": "0.13.0-dev.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dapi-grpc",
-  "version": "0.13.0-dev.1",
+  "version": "0.12.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2725,7 +2725,8 @@
     },
     "yargs-parser": {
       "version": "13.1.1",
-      "resolved": "",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+      "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
       "dev": true,
       "requires": {
         "camelcase": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,13 +25,22 @@
       }
     },
     "@dashevo/grpc-common": {
-      "version": "github:dashevo/js-grpc-common#12efa0933ec830e1ea2d767c8e7fa0ab56af8d15",
-      "from": "github:dashevo/js-grpc-common#metadata",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@dashevo/grpc-common/-/grpc-common-0.2.2.tgz",
+      "integrity": "sha512-7r2LWxCKpVbF3xqKPZxOXIvd63TLEX250ud5PG6Wk6IoUNBOFVVNlwIAziG4lz8i061FRVA/Yqd7xSF8o6tZwA==",
       "requires": {
         "@grpc/proto-loader": "^0.5.2",
         "grpc": "^1.24.0",
         "grpc-health-check": "^1.7.0",
-        "lodash.get": "^4.4.2"
+        "lodash.get": "^4.4.2",
+        "semver": "^7.3.2"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+        }
       }
     },
     "@grpc/proto-loader": {
@@ -2725,8 +2734,7 @@
     },
     "yargs-parser": {
       "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-      "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+      "resolved": "",
       "dev": true,
       "requires": {
         "camelcase": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,9 +25,8 @@
       }
     },
     "@dashevo/grpc-common": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@dashevo/grpc-common/-/grpc-common-0.2.0.tgz",
-      "integrity": "sha512-SzKl/1KCctkvX+ELVo9EybPLw2FLmMvqbLH7rQwPpmslOU7YyohmmGKm0UoZwn3BipZTj8f6tKBN3B9Eq3amYQ==",
+      "version": "github:dashevo/js-grpc-common#12efa0933ec830e1ea2d767c8e7fa0ab56af8d15",
+      "from": "github:dashevo/js-grpc-common#metadata",
       "requires": {
         "@grpc/proto-loader": "^0.5.2",
         "grpc": "^1.24.0",
@@ -36,9 +35,9 @@
       }
     },
     "@grpc/proto-loader": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.5.2.tgz",
-      "integrity": "sha512-eBKD/FPxQoY1x6QONW2nBd54QUEyzcFP9FenujmoeDPy1rutVSHki1s/wR68F6O1QfCNDx+ayBH1O2CVNMzyyw==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.5.4.tgz",
+      "integrity": "sha512-HTM4QpI9B2XFkPz7pjwMyMgZchJ93TVkL3kWPW8GDMDKYxsMnmf4w2TNMJK7+KNiYHS5cJrCEAFlF+AwtXWVPA==",
       "requires": {
         "lodash.camelcase": "^4.3.0",
         "protobufjs": "^6.8.6"
@@ -162,9 +161,9 @@
       "integrity": "sha512-QcAKpaO6nhHLlxWBvpc4WeLrTvPqlHOvaj0s5GriKkA1zq+bsFBPpfYCvQhLqLgYlIko8A9YrPdaMHCo5mBcpg=="
     },
     "acorn": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.0.tgz",
-      "integrity": "sha512-8oe72N3WPMjA+2zVG71Ia0nXZ8DpQH+QyyHO+p06jT8eg8FGG3FbcUIi8KziHlAfheJQZeoqbvq1mQSQHXKYLw==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+      "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
       "dev": true
     },
     "acorn-jsx": {
@@ -1360,9 +1359,9 @@
       }
     },
     "grpc-health-check": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/grpc-health-check/-/grpc-health-check-1.7.0.tgz",
-      "integrity": "sha512-yrjWW9OLalYfF1BPXn0uMgiVqpma8AoNckeoJTAfCngexkbNH6l4C1+ACC6o0AD5AoH9OrbHyzdzM8IxvMGgJA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/grpc-health-check/-/grpc-health-check-1.8.0.tgz",
+      "integrity": "sha512-Fqa35Bg4VhliZE3Yfe88mmYm0nRfKVr/QRYw5zP1jtn1R0f7wwJJqlXsjaoexJy+pVTVXZpP6CxmNGuEv/bngw==",
       "requires": {
         "google-protobuf": "^3.4.0",
         "grpc": "^1.6.0",
@@ -1732,18 +1731,18 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "^1.2.5"
       }
     },
     "mocha": {
@@ -1781,6 +1780,12 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
           "dev": true
         },
         "cliui": {
@@ -1840,6 +1845,21 @@
           "requires": {
             "p-locate": "^3.0.0",
             "path-exists": "^3.0.0"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
           }
         },
         "ms": {
@@ -1934,6 +1954,16 @@
             "which-module": "^2.0.0",
             "y18n": "^4.0.0",
             "yargs-parser": "^13.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "13.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+          "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }
@@ -2695,8 +2725,7 @@
     },
     "yargs-parser": {
       "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-      "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+      "resolved": "",
       "dev": true,
       "requires": {
         "camelcase": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dapi-grpc",
-  "version": "0.12.1",
+  "version": "0.13.0-dev.1",
   "description": "DAPI GRPC definition file and generated clients",
   "browser": "browser.js",
   "main": "node.js",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "check-package:version": "test $(jq -r .version package.json) = $(jq -r .version package-lock.json)",
     "prepublishOnly": "npm run build",
     "test": "npm run test:unit",
-    "test:unit": "mocha './test/unit/**/*.spec.js'"
+    "test:unit": "mocha './test/unit/**/*.spec.js'",
+    "prepare": "npm run build"
   },
   "contributors": [
     {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "homepage": "https://github.com/dashevo/dapi-grpc#readme",
   "dependencies": {
-    "@dashevo/grpc-common": "dashevo/js-grpc-common#metadata",
+    "@dashevo/grpc-common": "^0.2.2",
     "google-protobuf": "^3.8.0",
     "grpc": "^1.24.2",
     "grpc-web": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "homepage": "https://github.com/dashevo/dapi-grpc#readme",
   "dependencies": {
-    "@dashevo/grpc-common": "^0.2.0",
+    "@dashevo/grpc-common": "dashevo/js-grpc-common#metadata",
     "google-protobuf": "^3.8.0",
     "grpc": "^1.24.2",
     "grpc-web": "^1.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashevo/dapi-grpc",
-  "version": "0.13.0-dev.1",
+  "version": "0.12.1",
   "description": "DAPI GRPC definition file and generated clients",
   "browser": "browser.js",
   "main": "node.js",


### PR DESCRIPTION
BREAKING_CHANGE: you have to set up protocol version via `setProtocolVersion` method when using promise clients