### PR TITLE
feat: allow passing of options to calls in NodeJS clients

### DIFF
--- a/clients/nodejs/CorePromiseClient.js
+++ b/clients/nodejs/CorePromiseClient.js
@@ -90,9 +90,10 @@ class CorePromiseClient {
   /**
    * @param {!GetStatusRequest} getStatusRequest
    * @param {?Object<string, string>} metadata
+   * @param {Object} [options={}]
    * @return {Promise<!GetStatusResponse>}
    */
-  getStatus(getStatusRequest, metadata = {}) {
+  getStatus(getStatusRequest, metadata = {}, options = {}) {
     if (!isObject(metadata)) {
       throw new Error('metadata must be an object');
     }
@@ -112,6 +113,7 @@ class CorePromiseClient {
             ),
           ),
         ],
+        ...options,
       },
     );
   }
@@ -119,9 +121,10 @@ class CorePromiseClient {
   /**
    * @param {!GetBlockRequest} getBlockRequest
    * @param {?Object<string, string>} metadata
+   * @param {Object} [options={}]
    * @return {Promise<!GetBlockResponse>}
    */
-  getBlock(getBlockRequest, metadata = {}) {
+  getBlock(getBlockRequest, metadata = {}, options = {}) {
     if (!isObject(metadata)) {
       throw new Error('metadata must be an object');
     }
@@ -141,6 +144,7 @@ class CorePromiseClient {
             ),
           ),
         ],
+        ...options,
       },
     );
   }
@@ -148,9 +152,10 @@ class CorePromiseClient {
   /**
    * @param {!SendTransactionRequest} sendTransactionRequest
    * @param {?Object<string, string>} metadata
+   * @param {Object} [options={}]
    * @return {Promise<!SendTransactionResponse>}
    */
-  sendTransaction(sendTransactionRequest, metadata = {}) {
+  sendTransaction(sendTransactionRequest, metadata = {}, options = {}) {
     if (!isObject(metadata)) {
       throw new Error('metadata must be an object');
     }
@@ -170,6 +175,7 @@ class CorePromiseClient {
             ),
           ),
         ],
+        ...options,
       },
     );
   }
@@ -177,9 +183,10 @@ class CorePromiseClient {
   /**
    * @param {!GetTransactionRequest} getTransactionRequest
    * @param {?Object<string, string>} metadata
+   * @param {Object} [options={}]
    * @return {Promise<!GetTransactionResponse>}
    */
-  getTransaction(getTransactionRequest, metadata = {}) {
+  getTransaction(getTransactionRequest, metadata = {}, options = {}) {
     if (!isObject(metadata)) {
       throw new Error('metadata must be an object');
     }
@@ -199,6 +206,7 @@ class CorePromiseClient {
             ),
           ),
         ],
+        ...options,
       },
     );
   }
@@ -206,9 +214,10 @@ class CorePromiseClient {
   /**
    * @param {!GetEstimatedTransactionFeeRequest} getEstimatedTransactionFeeRequest
    * @param {?Object<string, string>} metadata
+   * @param {Object} [options={}]
    * @returns {Promise<!GetEstimatedTransactionFeeResponse>}
    */
-  getEstimatedTransactionFee(getEstimatedTransactionFeeRequest, metadata = {}) {
+  getEstimatedTransactionFee(getEstimatedTransactionFeeRequest, metadata = {}, options = {}) {
     if (!isObject(metadata)) {
       throw new Error('metadata must be an object');
     }
@@ -228,6 +237,7 @@ class CorePromiseClient {
             ),
           ),
         ],
+        ...options,
       },
     );
   }
@@ -235,10 +245,11 @@ class CorePromiseClient {
   /**
    * @param {!BlockHeadersWithChainLocksRequest} blockHeadersWithChainLocksRequest
    * @param {?Object<string, string>} metadata
+   * @param {Object} [options={}]
    * @return {!grpc.web.ClientReadableStream<!BlockHeadersWithChainLocksResponse>|undefined}
    *     The XHR Node Readable Stream
    */
-  subscribeToBlockHeadersWithChainLocks(blockHeadersWithChainLocksRequest, metadata = {}) {
+  subscribeToBlockHeadersWithChainLocks(blockHeadersWithChainLocksRequest, metadata = {}, options = {}) {
     if (!isObject(metadata)) {
       throw new Error('metadata must be an object');
     }
@@ -258,6 +269,7 @@ class CorePromiseClient {
             ),
           ),
         ],
+        ...options,
       },
     );
   }

--- a/clients/nodejs/CorePromiseClient.js
+++ b/clients/nodejs/CorePromiseClient.js
@@ -90,7 +90,7 @@ class CorePromiseClient {
   /**
    * @param {!GetStatusRequest} getStatusRequest
    * @param {?Object<string, string>} metadata
-   * @param {Object} [options={}]
+   * @param {CallOptions} [options={}]
    * @return {Promise<!GetStatusResponse>}
    */
   getStatus(getStatusRequest, metadata = {}, options = {}) {
@@ -121,7 +121,7 @@ class CorePromiseClient {
   /**
    * @param {!GetBlockRequest} getBlockRequest
    * @param {?Object<string, string>} metadata
-   * @param {Object} [options={}]
+   * @param {CallOptions} [options={}]
    * @return {Promise<!GetBlockResponse>}
    */
   getBlock(getBlockRequest, metadata = {}, options = {}) {
@@ -152,7 +152,7 @@ class CorePromiseClient {
   /**
    * @param {!SendTransactionRequest} sendTransactionRequest
    * @param {?Object<string, string>} metadata
-   * @param {Object} [options={}]
+   * @param {CallOptions} [options={}]
    * @return {Promise<!SendTransactionResponse>}
    */
   sendTransaction(sendTransactionRequest, metadata = {}, options = {}) {
@@ -183,7 +183,7 @@ class CorePromiseClient {
   /**
    * @param {!GetTransactionRequest} getTransactionRequest
    * @param {?Object<string, string>} metadata
-   * @param {Object} [options={}]
+   * @param {CallOptions} [options={}]
    * @return {Promise<!GetTransactionResponse>}
    */
   getTransaction(getTransactionRequest, metadata = {}, options = {}) {
@@ -214,7 +214,7 @@ class CorePromiseClient {
   /**
    * @param {!GetEstimatedTransactionFeeRequest} getEstimatedTransactionFeeRequest
    * @param {?Object<string, string>} metadata
-   * @param {Object} [options={}]
+   * @param {CallOptions} [options={}]
    * @returns {Promise<!GetEstimatedTransactionFeeResponse>}
    */
   getEstimatedTransactionFee(getEstimatedTransactionFeeRequest, metadata = {}, options = {}) {
@@ -245,11 +245,15 @@ class CorePromiseClient {
   /**
    * @param {!BlockHeadersWithChainLocksRequest} blockHeadersWithChainLocksRequest
    * @param {?Object<string, string>} metadata
-   * @param {Object} [options={}]
+   * @param {CallOptions} [options={}]
    * @return {!grpc.web.ClientReadableStream<!BlockHeadersWithChainLocksResponse>|undefined}
    *     The XHR Node Readable Stream
    */
-  subscribeToBlockHeadersWithChainLocks(blockHeadersWithChainLocksRequest, metadata = {}, options = {}) {
+  subscribeToBlockHeadersWithChainLocks(
+    blockHeadersWithChainLocksRequest,
+    metadata = {},
+    options = {},
+  ) {
     if (!isObject(metadata)) {
       throw new Error('metadata must be an object');
     }

--- a/clients/nodejs/PlatformPromiseClient.js
+++ b/clients/nodejs/PlatformPromiseClient.js
@@ -94,7 +94,7 @@ class PlatformPromiseClient {
   /**
    * @param {!ApplyStateTransitionRequest} applyStateTransitionRequest
    * @param {?Object<string, string>} metadata
-   * @param {Object} [options={}]
+   * @param {CallOptions} [options={}]
    * @return {Promise<!ApplyStateTransitionResponse>}
    */
   applyStateTransition(applyStateTransitionRequest, metadata = {}, options = {}) {
@@ -125,7 +125,7 @@ class PlatformPromiseClient {
   /**
    * @param {!GetIdentityRequest} getIdentityRequest
    * @param {?Object<string, string>} metadata
-   * @param {Object} [options={}]
+   * @param {CallOptions} [options={}]
    * @return {Promise<!GetIdentityResponse>}
    */
   getIdentity(getIdentityRequest, metadata = {}, options = {}) {
@@ -157,7 +157,7 @@ class PlatformPromiseClient {
    *
    * @param {!GetDataContractRequest} getDataContractRequest
    * @param {?Object<string, string>} metadata
-   * @param {Object} [options={}]
+   * @param {CallOptions} [options={}]
    * @returns {Promise<!GetDataContractResponse>}
    */
   getDataContract(getDataContractRequest, metadata = {}, options = {}) {
@@ -189,7 +189,7 @@ class PlatformPromiseClient {
    *
    * @param {!GetDocumentsRequest} getDocumentsRequest
    * @param {?Object<string, string>} metadata
-   * @param {Object} [options={}]
+   * @param {CallOptions} [options={}]
    * @returns {Promise<!GetDocumentsResponse>}
    */
   getDocuments(getDocumentsRequest, metadata = {}, options = {}) {
@@ -221,7 +221,7 @@ class PlatformPromiseClient {
    *
    * @param {!GetIdentityByFirstPublicKeyRequest} getIdentityByFirstPublicKeyRequest
    * @param {?Object<string, string>} metadata
-   * @param {Object} [options={}]
+   * @param {CallOptions} [options={}]
    * @returns {Promise<!GetDocumentsResponse>}
    */
   getIdentityByFirstPublicKey(getIdentityByFirstPublicKeyRequest, metadata = {}, options = {}) {
@@ -253,7 +253,7 @@ class PlatformPromiseClient {
    *
    * @param {!GetIdentityIdByFirstPublicKeyRequest} getIdentityIdByFirstPublicKeyRequest
    * @param {?Object<string, string>} metadata
-   * @param {Object} [options={}]
+   * @param {CallOptions} [options={}]
    * @returns {Promise<!GetDocumentsResponse>}
    */
   getIdentityIdByFirstPublicKey(getIdentityIdByFirstPublicKeyRequest, metadata = {}, options = {}) {

--- a/clients/nodejs/PlatformPromiseClient.js
+++ b/clients/nodejs/PlatformPromiseClient.js
@@ -94,9 +94,10 @@ class PlatformPromiseClient {
   /**
    * @param {!ApplyStateTransitionRequest} applyStateTransitionRequest
    * @param {?Object<string, string>} metadata
+   * @param {Object} [options={}]
    * @return {Promise<!ApplyStateTransitionResponse>}
    */
-  applyStateTransition(applyStateTransitionRequest, metadata = {}) {
+  applyStateTransition(applyStateTransitionRequest, metadata = {}, options = {}) {
     if (!isObject(metadata)) {
       throw new Error('metadata must be an object');
     }
@@ -116,6 +117,7 @@ class PlatformPromiseClient {
             ),
           ),
         ],
+        ...options,
       },
     );
   }
@@ -123,9 +125,10 @@ class PlatformPromiseClient {
   /**
    * @param {!GetIdentityRequest} getIdentityRequest
    * @param {?Object<string, string>} metadata
+   * @param {Object} [options={}]
    * @return {Promise<!GetIdentityResponse>}
    */
-  getIdentity(getIdentityRequest, metadata = {}) {
+  getIdentity(getIdentityRequest, metadata = {}, options = {}) {
     if (!isObject(metadata)) {
       throw new Error('metadata must be an object');
     }
@@ -145,6 +148,7 @@ class PlatformPromiseClient {
             ),
           ),
         ],
+        ...options,
       },
     );
   }
@@ -153,9 +157,10 @@ class PlatformPromiseClient {
    *
    * @param {!GetDataContractRequest} getDataContractRequest
    * @param {?Object<string, string>} metadata
+   * @param {Object} [options={}]
    * @returns {Promise<!GetDataContractResponse>}
    */
-  getDataContract(getDataContractRequest, metadata = {}) {
+  getDataContract(getDataContractRequest, metadata = {}, options = {}) {
     if (!isObject(metadata)) {
       throw new Error('metadata must be an object');
     }
@@ -175,6 +180,7 @@ class PlatformPromiseClient {
             ),
           ),
         ],
+        ...options,
       },
     );
   }
@@ -183,9 +189,10 @@ class PlatformPromiseClient {
    *
    * @param {!GetDocumentsRequest} getDocumentsRequest
    * @param {?Object<string, string>} metadata
+   * @param {Object} [options={}]
    * @returns {Promise<!GetDocumentsResponse>}
    */
-  getDocuments(getDocumentsRequest, metadata = {}) {
+  getDocuments(getDocumentsRequest, metadata = {}, options = {}) {
     if (!isObject(metadata)) {
       throw new Error('metadata must be an object');
     }
@@ -205,24 +212,19 @@ class PlatformPromiseClient {
             ),
           ),
         ],
+        ...options,
       },
     );
-  }
-
-  /**
-   * @param {string} protocolVersion
-   */
-  setProtocolVersion(protocolVersion) {
-    this.setProtocolVersion = protocolVersion;
   }
 
   /**
    *
    * @param {!GetIdentityByFirstPublicKeyRequest} getIdentityByFirstPublicKeyRequest
    * @param {?Object<string, string>} metadata
+   * @param {Object} [options={}]
    * @returns {Promise<!GetDocumentsResponse>}
    */
-  getIdentityByFirstPublicKey(getIdentityByFirstPublicKeyRequest, metadata = {}) {
+  getIdentityByFirstPublicKey(getIdentityByFirstPublicKeyRequest, metadata = {}, options = {}) {
     if (!isObject(metadata)) {
       throw new Error('metadata must be an object');
     }
@@ -242,18 +244,19 @@ class PlatformPromiseClient {
             ),
           ),
         ],
+        ...options,
       },
     );
   }
-
 
   /**
    *
    * @param {!GetIdentityIdByFirstPublicKeyRequest} getIdentityIdByFirstPublicKeyRequest
    * @param {?Object<string, string>} metadata
+   * @param {Object} [options={}]
    * @returns {Promise<!GetDocumentsResponse>}
    */
-  getIdentityIdByFirstPublicKey(getIdentityIdByFirstPublicKeyRequest, metadata = {}) {
+  getIdentityIdByFirstPublicKey(getIdentityIdByFirstPublicKeyRequest, metadata = {}, options = {}) {
     if (!isObject(metadata)) {
       throw new Error('metadata must be an object');
     }
@@ -273,8 +276,16 @@ class PlatformPromiseClient {
             ),
           ),
         ],
+        ...options,
       },
     );
+  }
+
+  /**
+   * @param {string} protocolVersion
+   */
+  setProtocolVersion(protocolVersion) {
+    this.setProtocolVersion = protocolVersion;
   }
 }
 

--- a/clients/nodejs/TransactionsFilterStreamPromiseClient.js
+++ b/clients/nodejs/TransactionsFilterStreamPromiseClient.js
@@ -57,10 +57,11 @@ class TransactionsFilterStreamPromiseClient {
   /**
    * @param {TransactionsWithProofsRequest} transactionsWithProofsRequest The request proto
    * @param {?Object<string, string>} metadata User defined call metadata
+   * @param {Object} [options={}]
    * @return {!grpc.web.ClientReadableStream<!TransactionsWithProofsResponse>|undefined}
    *     The XHR Node Readable Stream
    */
-  subscribeToTransactionsWithProofs(transactionsWithProofsRequest, metadata = {}) {
+  subscribeToTransactionsWithProofs(transactionsWithProofsRequest, metadata = {}, options = {}) {
     if (!isObject(metadata)) {
       throw new Error('metadata must be an object');
     }
@@ -80,6 +81,7 @@ class TransactionsFilterStreamPromiseClient {
             ),
           ),
         ],
+        ...options,
       },
     );
   }

--- a/clients/nodejs/TransactionsFilterStreamPromiseClient.js
+++ b/clients/nodejs/TransactionsFilterStreamPromiseClient.js
@@ -57,7 +57,7 @@ class TransactionsFilterStreamPromiseClient {
   /**
    * @param {TransactionsWithProofsRequest} transactionsWithProofsRequest The request proto
    * @param {?Object<string, string>} metadata User defined call metadata
-   * @param {Object} [options={}]
+   * @param {CallOptions} [options={}]
    * @return {!grpc.web.ClientReadableStream<!TransactionsWithProofsResponse>|undefined}
    *     The XHR Node Readable Stream
    */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Now it is possible to pass `options` object to every request call.


## What was done?
<!--- Describe your changes in detail -->
Added optional `options` field to every method of all 3 NodeJS clients.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With unit tests only. We need to test it separately using `mn-bootstrap`.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests (WIP)

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone (No milestones provided for the repo)
