### PR TITLE
feat: strip URL passed on to client and leave only ip/host:port pair

### DIFF
--- a/clients/nodejs/CorePromiseClient.js
+++ b/clients/nodejs/CorePromiseClient.js
@@ -52,6 +52,7 @@ const {
 } = require('./core_protoc');
 
 const getCoreDefinition = require('../../lib/getCoreDefinition');
+const stripHostname = require('../../lib/utils/stripHostname');
 
 const CoreNodeJSClient = getCoreDefinition();
 
@@ -62,7 +63,9 @@ class CorePromiseClient {
    * @param {?Object} options
    */
   constructor(hostname, credentials = grpc.credentials.createInsecure(), options = {}) {
-    this.client = new CoreNodeJSClient(hostname, credentials, options);
+    const strippedHostname = stripHostname(hostname);
+
+    this.client = new CoreNodeJSClient(strippedHostname, credentials, options);
 
     this.client.getStatus = promisify(
       this.client.getStatus.bind(this.client),

--- a/clients/nodejs/PlatformPromiseClient.js
+++ b/clients/nodejs/PlatformPromiseClient.js
@@ -52,6 +52,7 @@ const {
 } = require('./platform_protoc');
 
 const getPlatformDefinition = require('../../lib/getPlatformDefinition');
+const stripHostname = require('../../lib/utils/stripHostname');
 
 const PlatformNodeJSClient = getPlatformDefinition();
 
@@ -62,7 +63,9 @@ class PlatformPromiseClient {
    * @param {?Object} options
    */
   constructor(hostname, credentials = grpc.credentials.createInsecure(), options = {}) {
-    this.client = new PlatformNodeJSClient(hostname, credentials, options);
+    const strippedHostname = stripHostname(hostname);
+
+    this.client = new PlatformNodeJSClient(strippedHostname, credentials, options);
 
     this.client.applyStateTransition = promisify(
       this.client.applyStateTransition.bind(this.client),

--- a/clients/nodejs/TransactionsFilterStreamPromiseClient.js
+++ b/clients/nodejs/TransactionsFilterStreamPromiseClient.js
@@ -38,6 +38,7 @@ const {
 const getTransactionsFilterStreamDefinition = require(
   '../../lib/getTransactionsFilterStreamDefinition',
 );
+const stripHostname = require('../../lib/utils/stripHostname');
 
 const TransactionsFilterStreamNodeJSClient = getTransactionsFilterStreamDefinition();
 
@@ -49,7 +50,9 @@ class TransactionsFilterStreamPromiseClient {
    * @param {?Object} options
    */
   constructor(hostname, credentials = grpc.credentials.createInsecure(), options = {}) {
-    this.client = new TransactionsFilterStreamNodeJSClient(hostname, credentials, options);
+    const strippedHostname = stripHostname(hostname);
+
+    this.client = new TransactionsFilterStreamNodeJSClient(strippedHostname, credentials, options);
 
     this.protocolVersion = undefined;
   }

--- a/lib/utils/stripHostname.js
+++ b/lib/utils/stripHostname.js
@@ -1,0 +1,16 @@
+/**
+ * Remove everything except (hostname/ip):port pair
+ *
+ * @param {string} hostname
+ *
+ * @returns {string}
+ */
+function stripHostname(hostname) {
+  /**
+   * Following regexp matches first hostname or ip port pair
+   */
+  const [match] = hostname.match(/(\w+:[0-9]+)|((?:[0-9]{1,3}\.){3}[0-9]{1,3}:[0-9]+)/);
+  return match;
+}
+
+module.exports = stripHostname;

--- a/lib/utils/stripHostname.js
+++ b/lib/utils/stripHostname.js
@@ -1,3 +1,5 @@
+const { URL } = require('url');
+
 /**
  * Remove everything except (hostname/ip):port pair
  *
@@ -6,11 +8,8 @@
  * @returns {string}
  */
 function stripHostname(hostname) {
-  /**
-   * Following regexp matches first hostname or ip port pair
-   */
-  const [match] = hostname.match(/(\w+:[0-9]+)|((?:[0-9]{1,3}\.){3}[0-9]{1,3}:[0-9]+)/);
-  return match;
+  const url = new URL(hostname);
+  return url.host;
 }
 
 module.exports = stripHostname;

--- a/test/unit/clients/nodejs/CorePromiseClient.spec.js
+++ b/test/unit/clients/nodejs/CorePromiseClient.spec.js
@@ -9,7 +9,7 @@ describe('CorePromiseClient', () => {
     request = 'test request';
     response = 'test response';
 
-    corePromiseClient = new CorePromiseClient('localhost');
+    corePromiseClient = new CorePromiseClient('https://localhost/');
     corePromiseClient.client = {
       getStatus: this.sinon.stub().resolves(response),
       getBlock: this.sinon.stub().resolves(response),

--- a/test/unit/clients/nodejs/PlatformPromiseClient.spec.js
+++ b/test/unit/clients/nodejs/PlatformPromiseClient.spec.js
@@ -9,7 +9,7 @@ describe('PlatformPromiseClient', () => {
     request = 'test request';
     response = 'test response';
 
-    platformPromiseClient = new PlatformPromiseClient('localhost');
+    platformPromiseClient = new PlatformPromiseClient('https://localhost/');
     platformPromiseClient.client = {
       applyStateTransition: this.sinon.stub().resolves(response),
       getIdentity: this.sinon.stub().resolves(response),

--- a/test/unit/clients/nodejs/TransactionsFilterStreamPromiseClient.spec.js
+++ b/test/unit/clients/nodejs/TransactionsFilterStreamPromiseClient.spec.js
@@ -9,7 +9,7 @@ describe('TransactionsFilterStreamPromiseClient', () => {
     request = 'test request';
     response = 'test response';
 
-    transactionsFilterStreamPromiseClient = new TransactionsFilterStreamPromiseClient('localhost');
+    transactionsFilterStreamPromiseClient = new TransactionsFilterStreamPromiseClient('https://localhost/');
     transactionsFilterStreamPromiseClient.client = {
       subscribeToTransactionsWithProofs: this.sinon.stub().resolves(response),
     };

--- a/test/unit/utils/stripHostname.spec.js
+++ b/test/unit/utils/stripHostname.spec.js
@@ -20,29 +20,4 @@ describe('stripHostname', () => {
 
     expect(result).to.equal('127.0.0.1:3030');
   });
-
-  it('should strip https URL and leave only hostname:port pair', () => {
-    hostname = 'https://ip:3030/';
-
-    const result = stripHostname(hostname);
-
-    expect(result).to.equal('ip:3030');
-  });
-
-  it('should leave hostname:port pair as is', () => {
-    hostname = 'ip:3030';
-
-    const result = stripHostname(hostname);
-
-    expect(result).to.equal('ip:3030');
-  });
-
-
-  it('should leave ip:port pair as is', () => {
-    hostname = '127.0.0.1:3030';
-
-    const result = stripHostname(hostname);
-
-    expect(result).to.equal(hostname);
-  });
 });

--- a/test/unit/utils/stripHostname.spec.js
+++ b/test/unit/utils/stripHostname.spec.js
@@ -1,0 +1,48 @@
+const stripHostname = require('../../../lib/utils/stripHostname');
+
+describe('stripHostname', () => {
+  let hostname;
+
+  beforeEach(() => {
+    hostname = 'http://ip:3030/';
+  });
+
+  it('should strip everything and leave only hostname:port pair', () => {
+    const result = stripHostname(hostname);
+
+    expect(result).to.equal('ip:3030');
+  });
+
+  it('should strip everything and leave only ip:port pair', () => {
+    hostname = 'http://127.0.0.1:3030/?some=params';
+
+    const result = stripHostname(hostname);
+
+    expect(result).to.equal('127.0.0.1:3030');
+  });
+
+  it('should strip https URL and leave only hostname:port pair', () => {
+    hostname = 'https://ip:3030/';
+
+    const result = stripHostname(hostname);
+
+    expect(result).to.equal('ip:3030');
+  });
+
+  it('should leave hostname:port pair as is', () => {
+    hostname = 'ip:3030';
+
+    const result = stripHostname(hostname);
+
+    expect(result).to.equal('ip:3030');
+  });
+
+
+  it('should leave ip:port pair as is', () => {
+    hostname = '127.0.0.1:3030';
+
+    const result = stripHostname(hostname);
+
+    expect(result).to.equal(hostname);
+  });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We decided to pass full URL to our gRPC clients, but NodeJS only requires `hostname/ip:port` pair.

## What was done?
<!--- Describe your changes in detail -->
URL is stripped in the constructor.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With unit tests.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone (none provided)
