### PR TITLE
feat!: rename sendTransaction and applyStateTransition to broadcast

### DIFF
--- a/clients/java/org/dash/platform/dapi/v0/CoreGrpc.java
+++ b/clients/java/org/dash/platform/dapi/v0/CoreGrpc.java
@@ -52,16 +52,16 @@ public final class CoreGrpc {
               org.dash.platform.dapi.v0.CoreOuterClass.GetBlockResponse.getDefaultInstance()))
           .build();
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  public static final io.grpc.MethodDescriptor<org.dash.platform.dapi.v0.CoreOuterClass.SendTransactionRequest,
-      org.dash.platform.dapi.v0.CoreOuterClass.SendTransactionResponse> METHOD_SEND_TRANSACTION =
-      io.grpc.MethodDescriptor.<org.dash.platform.dapi.v0.CoreOuterClass.SendTransactionRequest, org.dash.platform.dapi.v0.CoreOuterClass.SendTransactionResponse>newBuilder()
+  public static final io.grpc.MethodDescriptor<org.dash.platform.dapi.v0.CoreOuterClass.BroadcastTransactionRequest,
+      org.dash.platform.dapi.v0.CoreOuterClass.BroadcastTransactionResponse> METHOD_BROADCAST_TRANSACTION =
+      io.grpc.MethodDescriptor.<org.dash.platform.dapi.v0.CoreOuterClass.BroadcastTransactionRequest, org.dash.platform.dapi.v0.CoreOuterClass.BroadcastTransactionResponse>newBuilder()
           .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
           .setFullMethodName(generateFullMethodName(
-              "org.dash.platform.dapi.v0.Core", "sendTransaction"))
+              "org.dash.platform.dapi.v0.Core", "broadcastTransaction"))
           .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              org.dash.platform.dapi.v0.CoreOuterClass.SendTransactionRequest.getDefaultInstance()))
+              org.dash.platform.dapi.v0.CoreOuterClass.BroadcastTransactionRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              org.dash.platform.dapi.v0.CoreOuterClass.SendTransactionResponse.getDefaultInstance()))
+              org.dash.platform.dapi.v0.CoreOuterClass.BroadcastTransactionResponse.getDefaultInstance()))
           .build();
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<org.dash.platform.dapi.v0.CoreOuterClass.GetTransactionRequest,
@@ -143,9 +143,9 @@ public final class CoreGrpc {
 
     /**
      */
-    public void sendTransaction(org.dash.platform.dapi.v0.CoreOuterClass.SendTransactionRequest request,
-        io.grpc.stub.StreamObserver<org.dash.platform.dapi.v0.CoreOuterClass.SendTransactionResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(METHOD_SEND_TRANSACTION, responseObserver);
+    public void broadcastTransaction(org.dash.platform.dapi.v0.CoreOuterClass.BroadcastTransactionRequest request,
+        io.grpc.stub.StreamObserver<org.dash.platform.dapi.v0.CoreOuterClass.BroadcastTransactionResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_BROADCAST_TRANSACTION, responseObserver);
     }
 
     /**
@@ -186,12 +186,12 @@ public final class CoreGrpc {
                 org.dash.platform.dapi.v0.CoreOuterClass.GetBlockResponse>(
                   this, METHODID_GET_BLOCK)))
           .addMethod(
-            METHOD_SEND_TRANSACTION,
+            METHOD_BROADCAST_TRANSACTION,
             asyncUnaryCall(
               new MethodHandlers<
-                org.dash.platform.dapi.v0.CoreOuterClass.SendTransactionRequest,
-                org.dash.platform.dapi.v0.CoreOuterClass.SendTransactionResponse>(
-                  this, METHODID_SEND_TRANSACTION)))
+                org.dash.platform.dapi.v0.CoreOuterClass.BroadcastTransactionRequest,
+                org.dash.platform.dapi.v0.CoreOuterClass.BroadcastTransactionResponse>(
+                  this, METHODID_BROADCAST_TRANSACTION)))
           .addMethod(
             METHOD_GET_TRANSACTION,
             asyncUnaryCall(
@@ -253,10 +253,10 @@ public final class CoreGrpc {
 
     /**
      */
-    public void sendTransaction(org.dash.platform.dapi.v0.CoreOuterClass.SendTransactionRequest request,
-        io.grpc.stub.StreamObserver<org.dash.platform.dapi.v0.CoreOuterClass.SendTransactionResponse> responseObserver) {
+    public void broadcastTransaction(org.dash.platform.dapi.v0.CoreOuterClass.BroadcastTransactionRequest request,
+        io.grpc.stub.StreamObserver<org.dash.platform.dapi.v0.CoreOuterClass.BroadcastTransactionResponse> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(METHOD_SEND_TRANSACTION, getCallOptions()), request, responseObserver);
+          getChannel().newCall(METHOD_BROADCAST_TRANSACTION, getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -318,9 +318,9 @@ public final class CoreGrpc {
 
     /**
      */
-    public org.dash.platform.dapi.v0.CoreOuterClass.SendTransactionResponse sendTransaction(org.dash.platform.dapi.v0.CoreOuterClass.SendTransactionRequest request) {
+    public org.dash.platform.dapi.v0.CoreOuterClass.BroadcastTransactionResponse broadcastTransaction(org.dash.platform.dapi.v0.CoreOuterClass.BroadcastTransactionRequest request) {
       return blockingUnaryCall(
-          getChannel(), METHOD_SEND_TRANSACTION, getCallOptions(), request);
+          getChannel(), METHOD_BROADCAST_TRANSACTION, getCallOptions(), request);
     }
 
     /**
@@ -382,10 +382,10 @@ public final class CoreGrpc {
 
     /**
      */
-    public com.google.common.util.concurrent.ListenableFuture<org.dash.platform.dapi.v0.CoreOuterClass.SendTransactionResponse> sendTransaction(
-        org.dash.platform.dapi.v0.CoreOuterClass.SendTransactionRequest request) {
+    public com.google.common.util.concurrent.ListenableFuture<org.dash.platform.dapi.v0.CoreOuterClass.BroadcastTransactionResponse> broadcastTransaction(
+        org.dash.platform.dapi.v0.CoreOuterClass.BroadcastTransactionRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(METHOD_SEND_TRANSACTION, getCallOptions()), request);
+          getChannel().newCall(METHOD_BROADCAST_TRANSACTION, getCallOptions()), request);
     }
 
     /**
@@ -407,7 +407,7 @@ public final class CoreGrpc {
 
   private static final int METHODID_GET_STATUS = 0;
   private static final int METHODID_GET_BLOCK = 1;
-  private static final int METHODID_SEND_TRANSACTION = 2;
+  private static final int METHODID_BROADCAST_TRANSACTION = 2;
   private static final int METHODID_GET_TRANSACTION = 3;
   private static final int METHODID_GET_ESTIMATED_TRANSACTION_FEE = 4;
   private static final int METHODID_SUBSCRIBE_TO_BLOCK_HEADERS_WITH_CHAIN_LOCKS = 5;
@@ -437,9 +437,9 @@ public final class CoreGrpc {
           serviceImpl.getBlock((org.dash.platform.dapi.v0.CoreOuterClass.GetBlockRequest) request,
               (io.grpc.stub.StreamObserver<org.dash.platform.dapi.v0.CoreOuterClass.GetBlockResponse>) responseObserver);
           break;
-        case METHODID_SEND_TRANSACTION:
-          serviceImpl.sendTransaction((org.dash.platform.dapi.v0.CoreOuterClass.SendTransactionRequest) request,
-              (io.grpc.stub.StreamObserver<org.dash.platform.dapi.v0.CoreOuterClass.SendTransactionResponse>) responseObserver);
+        case METHODID_BROADCAST_TRANSACTION:
+          serviceImpl.broadcastTransaction((org.dash.platform.dapi.v0.CoreOuterClass.BroadcastTransactionRequest) request,
+              (io.grpc.stub.StreamObserver<org.dash.platform.dapi.v0.CoreOuterClass.BroadcastTransactionResponse>) responseObserver);
           break;
         case METHODID_GET_TRANSACTION:
           serviceImpl.getTransaction((org.dash.platform.dapi.v0.CoreOuterClass.GetTransactionRequest) request,
@@ -488,7 +488,7 @@ public final class CoreGrpc {
               .setSchemaDescriptor(new CoreDescriptorSupplier())
               .addMethod(METHOD_GET_STATUS)
               .addMethod(METHOD_GET_BLOCK)
-              .addMethod(METHOD_SEND_TRANSACTION)
+              .addMethod(METHOD_BROADCAST_TRANSACTION)
               .addMethod(METHOD_GET_TRANSACTION)
               .addMethod(METHOD_GET_ESTIMATED_TRANSACTION_FEE)
               .addMethod(METHOD_SUBSCRIBE_TO_BLOCK_HEADERS_WITH_CHAIN_LOCKS)

--- a/clients/java/org/dash/platform/dapi/v0/PlatformGrpc.java
+++ b/clients/java/org/dash/platform/dapi/v0/PlatformGrpc.java
@@ -28,16 +28,16 @@ public final class PlatformGrpc {
 
   // Static method descriptors that strictly reflect the proto.
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  public static final io.grpc.MethodDescriptor<org.dash.platform.dapi.v0.PlatformOuterClass.ApplyStateTransitionRequest,
-      org.dash.platform.dapi.v0.PlatformOuterClass.ApplyStateTransitionResponse> METHOD_APPLY_STATE_TRANSITION =
-      io.grpc.MethodDescriptor.<org.dash.platform.dapi.v0.PlatformOuterClass.ApplyStateTransitionRequest, org.dash.platform.dapi.v0.PlatformOuterClass.ApplyStateTransitionResponse>newBuilder()
+  public static final io.grpc.MethodDescriptor<org.dash.platform.dapi.v0.PlatformOuterClass.BroadcastStateTransitionRequest,
+      org.dash.platform.dapi.v0.PlatformOuterClass.BroadcastStateTransitionResponse> METHOD_BROADCAST_STATE_TRANSITION =
+      io.grpc.MethodDescriptor.<org.dash.platform.dapi.v0.PlatformOuterClass.BroadcastStateTransitionRequest, org.dash.platform.dapi.v0.PlatformOuterClass.BroadcastStateTransitionResponse>newBuilder()
           .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
           .setFullMethodName(generateFullMethodName(
-              "org.dash.platform.dapi.v0.Platform", "applyStateTransition"))
+              "org.dash.platform.dapi.v0.Platform", "broadcastStateTransition"))
           .setRequestMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              org.dash.platform.dapi.v0.PlatformOuterClass.ApplyStateTransitionRequest.getDefaultInstance()))
+              org.dash.platform.dapi.v0.PlatformOuterClass.BroadcastStateTransitionRequest.getDefaultInstance()))
           .setResponseMarshaller(io.grpc.protobuf.ProtoUtils.marshaller(
-              org.dash.platform.dapi.v0.PlatformOuterClass.ApplyStateTransitionResponse.getDefaultInstance()))
+              org.dash.platform.dapi.v0.PlatformOuterClass.BroadcastStateTransitionResponse.getDefaultInstance()))
           .build();
   @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
   public static final io.grpc.MethodDescriptor<org.dash.platform.dapi.v0.PlatformOuterClass.GetIdentityRequest,
@@ -129,9 +129,9 @@ public final class PlatformGrpc {
 
     /**
      */
-    public void applyStateTransition(org.dash.platform.dapi.v0.PlatformOuterClass.ApplyStateTransitionRequest request,
-        io.grpc.stub.StreamObserver<org.dash.platform.dapi.v0.PlatformOuterClass.ApplyStateTransitionResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(METHOD_APPLY_STATE_TRANSITION, responseObserver);
+    public void broadcastStateTransition(org.dash.platform.dapi.v0.PlatformOuterClass.BroadcastStateTransitionRequest request,
+        io.grpc.stub.StreamObserver<org.dash.platform.dapi.v0.PlatformOuterClass.BroadcastStateTransitionResponse> responseObserver) {
+      asyncUnimplementedUnaryCall(METHOD_BROADCAST_STATE_TRANSITION, responseObserver);
     }
 
     /**
@@ -172,12 +172,12 @@ public final class PlatformGrpc {
     @java.lang.Override public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-            METHOD_APPLY_STATE_TRANSITION,
+            METHOD_BROADCAST_STATE_TRANSITION,
             asyncUnaryCall(
               new MethodHandlers<
-                org.dash.platform.dapi.v0.PlatformOuterClass.ApplyStateTransitionRequest,
-                org.dash.platform.dapi.v0.PlatformOuterClass.ApplyStateTransitionResponse>(
-                  this, METHODID_APPLY_STATE_TRANSITION)))
+                org.dash.platform.dapi.v0.PlatformOuterClass.BroadcastStateTransitionRequest,
+                org.dash.platform.dapi.v0.PlatformOuterClass.BroadcastStateTransitionResponse>(
+                  this, METHODID_BROADCAST_STATE_TRANSITION)))
           .addMethod(
             METHOD_GET_IDENTITY,
             asyncUnaryCall(
@@ -237,10 +237,10 @@ public final class PlatformGrpc {
 
     /**
      */
-    public void applyStateTransition(org.dash.platform.dapi.v0.PlatformOuterClass.ApplyStateTransitionRequest request,
-        io.grpc.stub.StreamObserver<org.dash.platform.dapi.v0.PlatformOuterClass.ApplyStateTransitionResponse> responseObserver) {
+    public void broadcastStateTransition(org.dash.platform.dapi.v0.PlatformOuterClass.BroadcastStateTransitionRequest request,
+        io.grpc.stub.StreamObserver<org.dash.platform.dapi.v0.PlatformOuterClass.BroadcastStateTransitionResponse> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(METHOD_APPLY_STATE_TRANSITION, getCallOptions()), request, responseObserver);
+          getChannel().newCall(METHOD_BROADCAST_STATE_TRANSITION, getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -304,9 +304,9 @@ public final class PlatformGrpc {
 
     /**
      */
-    public org.dash.platform.dapi.v0.PlatformOuterClass.ApplyStateTransitionResponse applyStateTransition(org.dash.platform.dapi.v0.PlatformOuterClass.ApplyStateTransitionRequest request) {
+    public org.dash.platform.dapi.v0.PlatformOuterClass.BroadcastStateTransitionResponse broadcastStateTransition(org.dash.platform.dapi.v0.PlatformOuterClass.BroadcastStateTransitionRequest request) {
       return blockingUnaryCall(
-          getChannel(), METHOD_APPLY_STATE_TRANSITION, getCallOptions(), request);
+          getChannel(), METHOD_BROADCAST_STATE_TRANSITION, getCallOptions(), request);
     }
 
     /**
@@ -365,10 +365,10 @@ public final class PlatformGrpc {
 
     /**
      */
-    public com.google.common.util.concurrent.ListenableFuture<org.dash.platform.dapi.v0.PlatformOuterClass.ApplyStateTransitionResponse> applyStateTransition(
-        org.dash.platform.dapi.v0.PlatformOuterClass.ApplyStateTransitionRequest request) {
+    public com.google.common.util.concurrent.ListenableFuture<org.dash.platform.dapi.v0.PlatformOuterClass.BroadcastStateTransitionResponse> broadcastStateTransition(
+        org.dash.platform.dapi.v0.PlatformOuterClass.BroadcastStateTransitionRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(METHOD_APPLY_STATE_TRANSITION, getCallOptions()), request);
+          getChannel().newCall(METHOD_BROADCAST_STATE_TRANSITION, getCallOptions()), request);
     }
 
     /**
@@ -412,7 +412,7 @@ public final class PlatformGrpc {
     }
   }
 
-  private static final int METHODID_APPLY_STATE_TRANSITION = 0;
+  private static final int METHODID_BROADCAST_STATE_TRANSITION = 0;
   private static final int METHODID_GET_IDENTITY = 1;
   private static final int METHODID_GET_DATA_CONTRACT = 2;
   private static final int METHODID_GET_DOCUMENTS = 3;
@@ -436,9 +436,9 @@ public final class PlatformGrpc {
     @java.lang.SuppressWarnings("unchecked")
     public void invoke(Req request, io.grpc.stub.StreamObserver<Resp> responseObserver) {
       switch (methodId) {
-        case METHODID_APPLY_STATE_TRANSITION:
-          serviceImpl.applyStateTransition((org.dash.platform.dapi.v0.PlatformOuterClass.ApplyStateTransitionRequest) request,
-              (io.grpc.stub.StreamObserver<org.dash.platform.dapi.v0.PlatformOuterClass.ApplyStateTransitionResponse>) responseObserver);
+        case METHODID_BROADCAST_STATE_TRANSITION:
+          serviceImpl.broadcastStateTransition((org.dash.platform.dapi.v0.PlatformOuterClass.BroadcastStateTransitionRequest) request,
+              (io.grpc.stub.StreamObserver<org.dash.platform.dapi.v0.PlatformOuterClass.BroadcastStateTransitionResponse>) responseObserver);
           break;
         case METHODID_GET_IDENTITY:
           serviceImpl.getIdentity((org.dash.platform.dapi.v0.PlatformOuterClass.GetIdentityRequest) request,
@@ -493,7 +493,7 @@ public final class PlatformGrpc {
         if (result == null) {
           serviceDescriptor = result = io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
               .setSchemaDescriptor(new PlatformDescriptorSupplier())
-              .addMethod(METHOD_APPLY_STATE_TRANSITION)
+              .addMethod(METHOD_BROADCAST_STATE_TRANSITION)
               .addMethod(METHOD_GET_IDENTITY)
               .addMethod(METHOD_GET_DATA_CONTRACT)
               .addMethod(METHOD_GET_DOCUMENTS)

--- a/clients/nodejs/CorePromiseClient.js
+++ b/clients/nodejs/CorePromiseClient.js
@@ -27,8 +27,8 @@ const {
             GetStatusResponse: PBJSGetStatusResponse,
             GetBlockRequest: PBJSGetBlockRequest,
             GetBlockResponse: PBJSGetBlockResponse,
-            SendTransactionRequest: PBJSSendTransactionRequest,
-            SendTransactionResponse: PBJSSendTransactionResponse,
+            BroadcastTransactionRequest: PBJSBroadcastTransactionRequest,
+            BroadcastTransactionResponse: PBJSBroadcastTransactionResponse,
             GetTransactionRequest: PBJSGetTransactionRequest,
             GetTransactionResponse: PBJSGetTransactionResponse,
             BlockHeadersWithChainLocksRequest: PBJSBlockHeadersWithChainLocksRequest,
@@ -45,7 +45,7 @@ const {
 const {
   GetStatusResponse: ProtocGetStatusResponse,
   GetBlockResponse: ProtocGetBlockResponse,
-  SendTransactionResponse: ProtocSendTransactionResponse,
+  BroadcastTransactionResponse: ProtocBroadcastTransactionResponse,
   GetTransactionResponse: ProtocGetTransactionResponse,
   BlockHeadersWithChainLocksResponse: ProtocBlockHeadersWithChainLocksResponse,
   GetEstimatedTransactionFeeResponse: ProtocGetEstimatedTransactionFeeResponse,
@@ -75,8 +75,8 @@ class CorePromiseClient {
       this.client.getBlock.bind(this.client),
     );
 
-    this.client.sendTransaction = promisify(
-      this.client.sendTransaction.bind(this.client),
+    this.client.broadcastTransaction = promisify(
+      this.client.broadcastTransaction.bind(this.client),
     );
 
     this.client.getTransaction = promisify(
@@ -153,28 +153,28 @@ class CorePromiseClient {
   }
 
   /**
-   * @param {!SendTransactionRequest} sendTransactionRequest
+   * @param {!BroadcastTransactionRequest} broadcastTransactionRequest
    * @param {?Object<string, string>} metadata
    * @param {CallOptions} [options={}]
-   * @return {Promise<!SendTransactionResponse>}
+   * @return {Promise<!BroadcastTransactionResponse>}
    */
-  sendTransaction(sendTransactionRequest, metadata = {}, options = {}) {
+  broadcastTransaction(broadcastTransactionRequest, metadata = {}, options = {}) {
     if (!isObject(metadata)) {
       throw new Error('metadata must be an object');
     }
 
-    return this.client.sendTransaction(
-      sendTransactionRequest,
+    return this.client.broadcastTransaction(
+      broadcastTransactionRequest,
       convertObjectToMetadata(metadata),
       {
         interceptors: [
           jsonToProtobufInterceptorFactory(
             jsonToProtobufFactory(
-              ProtocSendTransactionResponse,
-              PBJSSendTransactionResponse,
+              ProtocBroadcastTransactionResponse,
+              PBJSBroadcastTransactionResponse,
             ),
             protobufToJsonFactory(
-              PBJSSendTransactionRequest,
+              PBJSBroadcastTransactionRequest,
             ),
           ),
         ],

--- a/clients/nodejs/PlatformPromiseClient.js
+++ b/clients/nodejs/PlatformPromiseClient.js
@@ -23,8 +23,8 @@ const {
       platform: {
         dapi: {
           v0: {
-            ApplyStateTransitionRequest: PBJSApplyStateTransitionRequest,
-            ApplyStateTransitionResponse: PBJSApplyStateTransitionResponse,
+            BroadcastStateTransitionRequest: PBJSBroadcastStateTransitionRequest,
+            BroadcastStateTransitionResponse: PBJSBroadcastStateTransitionResponse,
             GetIdentityRequest: PBJSGetIdentityRequest,
             GetIdentityResponse: PBJSGetIdentityResponse,
             GetDataContractRequest: PBJSGetDataContractRequest,
@@ -43,7 +43,7 @@ const {
 } = require('./platform_pbjs');
 
 const {
-  ApplyStateTransitionResponse: ProtocApplyStateTransitionResponse,
+  BroadcastStateTransitionResponse: ProtocBroadcastStateTransitionResponse,
   GetIdentityResponse: ProtocGetIdentityResponse,
   GetDataContractResponse: ProtocGetDataContractResponse,
   GetDocumentsResponse: ProtocGetDocumentsResponse,
@@ -67,8 +67,8 @@ class PlatformPromiseClient {
 
     this.client = new PlatformNodeJSClient(strippedHostname, credentials, options);
 
-    this.client.applyStateTransition = promisify(
-      this.client.applyStateTransition.bind(this.client),
+    this.client.broadcastStateTransition = promisify(
+      this.client.broadcastStateTransition.bind(this.client),
     );
 
     this.client.getIdentity = promisify(
@@ -95,28 +95,28 @@ class PlatformPromiseClient {
   }
 
   /**
-   * @param {!ApplyStateTransitionRequest} applyStateTransitionRequest
+   * @param {!BroadcastStateTransitionRequest} broadcastStateTransitionRequest
    * @param {?Object<string, string>} metadata
    * @param {CallOptions} [options={}]
-   * @return {Promise<!ApplyStateTransitionResponse>}
+   * @return {Promise<!BroadcastStateTransitionResponse>}
    */
-  applyStateTransition(applyStateTransitionRequest, metadata = {}, options = {}) {
+  broadcastStateTransition(broadcastStateTransitionRequest, metadata = {}, options = {}) {
     if (!isObject(metadata)) {
       throw new Error('metadata must be an object');
     }
 
-    return this.client.applyStateTransition(
-      applyStateTransitionRequest,
+    return this.client.broadcastStateTransition(
+      broadcastStateTransitionRequest,
       convertObjectToMetadata(metadata),
       {
         interceptors: [
           jsonToProtobufInterceptorFactory(
             jsonToProtobufFactory(
-              ProtocApplyStateTransitionResponse,
-              PBJSApplyStateTransitionResponse,
+              ProtocBroadcastStateTransitionResponse,
+              PBJSBroadcastStateTransitionResponse,
             ),
             protobufToJsonFactory(
-              PBJSApplyStateTransitionRequest,
+              PBJSBroadcastStateTransitionRequest,
             ),
           ),
         ],

--- a/clients/objective-c/Core.pbobjc.h
+++ b/clients/objective-c/Core.pbobjc.h
@@ -135,15 +135,15 @@ typedef GPB_ENUM(GetBlockResponse_FieldNumber) {
 
 @end
 
-#pragma mark - SendTransactionRequest
+#pragma mark - BroadcastTransactionRequest
 
-typedef GPB_ENUM(SendTransactionRequest_FieldNumber) {
-  SendTransactionRequest_FieldNumber_Transaction = 1,
-  SendTransactionRequest_FieldNumber_AllowHighFees = 2,
-  SendTransactionRequest_FieldNumber_BypassLimits = 3,
+typedef GPB_ENUM(BroadcastTransactionRequest_FieldNumber) {
+  BroadcastTransactionRequest_FieldNumber_Transaction = 1,
+  BroadcastTransactionRequest_FieldNumber_AllowHighFees = 2,
+  BroadcastTransactionRequest_FieldNumber_BypassLimits = 3,
 };
 
-@interface SendTransactionRequest : GPBMessage
+@interface BroadcastTransactionRequest : GPBMessage
 
 @property(nonatomic, readwrite, copy, null_resettable) NSData *transaction;
 
@@ -153,13 +153,13 @@ typedef GPB_ENUM(SendTransactionRequest_FieldNumber) {
 
 @end
 
-#pragma mark - SendTransactionResponse
+#pragma mark - BroadcastTransactionResponse
 
-typedef GPB_ENUM(SendTransactionResponse_FieldNumber) {
-  SendTransactionResponse_FieldNumber_TransactionId = 1,
+typedef GPB_ENUM(BroadcastTransactionResponse_FieldNumber) {
+  BroadcastTransactionResponse_FieldNumber_TransactionId = 1,
 };
 
-@interface SendTransactionResponse : GPBMessage
+@interface BroadcastTransactionResponse : GPBMessage
 
 @property(nonatomic, readwrite, copy, null_resettable) NSString *transactionId;
 

--- a/clients/objective-c/Core.pbobjc.m
+++ b/clients/objective-c/Core.pbobjc.m
@@ -334,18 +334,18 @@ typedef struct GetBlockResponse__storage_ {
 
 @end
 
-#pragma mark - SendTransactionRequest
+#pragma mark - BroadcastTransactionRequest
 
-@implementation SendTransactionRequest
+@implementation BroadcastTransactionRequest
 
 @dynamic transaction;
 @dynamic allowHighFees;
 @dynamic bypassLimits;
 
-typedef struct SendTransactionRequest__storage_ {
+typedef struct BroadcastTransactionRequest__storage_ {
   uint32_t _has_storage_[1];
   NSData *transaction;
-} SendTransactionRequest__storage_;
+} BroadcastTransactionRequest__storage_;
 
 // This method is threadsafe because it is initially called
 // in +initialize for each subclass.
@@ -356,16 +356,16 @@ typedef struct SendTransactionRequest__storage_ {
       {
         .name = "transaction",
         .dataTypeSpecific.className = NULL,
-        .number = SendTransactionRequest_FieldNumber_Transaction,
+        .number = BroadcastTransactionRequest_FieldNumber_Transaction,
         .hasIndex = 0,
-        .offset = (uint32_t)offsetof(SendTransactionRequest__storage_, transaction),
+        .offset = (uint32_t)offsetof(BroadcastTransactionRequest__storage_, transaction),
         .flags = GPBFieldOptional,
         .dataType = GPBDataTypeBytes,
       },
       {
         .name = "allowHighFees",
         .dataTypeSpecific.className = NULL,
-        .number = SendTransactionRequest_FieldNumber_AllowHighFees,
+        .number = BroadcastTransactionRequest_FieldNumber_AllowHighFees,
         .hasIndex = 1,
         .offset = 2,  // Stored in _has_storage_ to save space.
         .flags = GPBFieldOptional,
@@ -374,7 +374,7 @@ typedef struct SendTransactionRequest__storage_ {
       {
         .name = "bypassLimits",
         .dataTypeSpecific.className = NULL,
-        .number = SendTransactionRequest_FieldNumber_BypassLimits,
+        .number = BroadcastTransactionRequest_FieldNumber_BypassLimits,
         .hasIndex = 3,
         .offset = 4,  // Stored in _has_storage_ to save space.
         .flags = GPBFieldOptional,
@@ -382,12 +382,12 @@ typedef struct SendTransactionRequest__storage_ {
       },
     };
     GPBDescriptor *localDescriptor =
-        [GPBDescriptor allocDescriptorForClass:[SendTransactionRequest class]
+        [GPBDescriptor allocDescriptorForClass:[BroadcastTransactionRequest class]
                                      rootClass:[CoreRoot class]
                                           file:CoreRoot_FileDescriptor()
                                         fields:fields
                                     fieldCount:(uint32_t)(sizeof(fields) / sizeof(GPBMessageFieldDescription))
-                                   storageSize:sizeof(SendTransactionRequest__storage_)
+                                   storageSize:sizeof(BroadcastTransactionRequest__storage_)
                                          flags:GPBDescriptorInitializationFlag_None];
     NSAssert(descriptor == nil, @"Startup recursed!");
     descriptor = localDescriptor;
@@ -397,16 +397,16 @@ typedef struct SendTransactionRequest__storage_ {
 
 @end
 
-#pragma mark - SendTransactionResponse
+#pragma mark - BroadcastTransactionResponse
 
-@implementation SendTransactionResponse
+@implementation BroadcastTransactionResponse
 
 @dynamic transactionId;
 
-typedef struct SendTransactionResponse__storage_ {
+typedef struct BroadcastTransactionResponse__storage_ {
   uint32_t _has_storage_[1];
   NSString *transactionId;
-} SendTransactionResponse__storage_;
+} BroadcastTransactionResponse__storage_;
 
 // This method is threadsafe because it is initially called
 // in +initialize for each subclass.
@@ -417,20 +417,20 @@ typedef struct SendTransactionResponse__storage_ {
       {
         .name = "transactionId",
         .dataTypeSpecific.className = NULL,
-        .number = SendTransactionResponse_FieldNumber_TransactionId,
+        .number = BroadcastTransactionResponse_FieldNumber_TransactionId,
         .hasIndex = 0,
-        .offset = (uint32_t)offsetof(SendTransactionResponse__storage_, transactionId),
+        .offset = (uint32_t)offsetof(BroadcastTransactionResponse__storage_, transactionId),
         .flags = GPBFieldOptional,
         .dataType = GPBDataTypeString,
       },
     };
     GPBDescriptor *localDescriptor =
-        [GPBDescriptor allocDescriptorForClass:[SendTransactionResponse class]
+        [GPBDescriptor allocDescriptorForClass:[BroadcastTransactionResponse class]
                                      rootClass:[CoreRoot class]
                                           file:CoreRoot_FileDescriptor()
                                         fields:fields
                                     fieldCount:(uint32_t)(sizeof(fields) / sizeof(GPBMessageFieldDescription))
-                                   storageSize:sizeof(SendTransactionResponse__storage_)
+                                   storageSize:sizeof(BroadcastTransactionResponse__storage_)
                                          flags:GPBDescriptorInitializationFlag_None];
     NSAssert(descriptor == nil, @"Startup recursed!");
     descriptor = localDescriptor;

--- a/clients/objective-c/Core.pbrpc.h
+++ b/clients/objective-c/Core.pbrpc.h
@@ -25,11 +25,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (GRPCProtoCall *)RPCTogetBlockWithRequest:(GetBlockRequest *)request handler:(void(^)(GetBlockResponse *_Nullable response, NSError *_Nullable error))handler;
 
 
-#pragma mark sendTransaction(SendTransactionRequest) returns (SendTransactionResponse)
+#pragma mark broadcastTransaction(BroadcastTransactionRequest) returns (BroadcastTransactionResponse)
 
-- (void)sendTransactionWithRequest:(SendTransactionRequest *)request handler:(void(^)(SendTransactionResponse *_Nullable response, NSError *_Nullable error))handler;
+- (void)broadcastTransactionWithRequest:(BroadcastTransactionRequest *)request handler:(void(^)(BroadcastTransactionResponse *_Nullable response, NSError *_Nullable error))handler;
 
-- (GRPCProtoCall *)RPCTosendTransactionWithRequest:(SendTransactionRequest *)request handler:(void(^)(SendTransactionResponse *_Nullable response, NSError *_Nullable error))handler;
+- (GRPCProtoCall *)RPCTobroadcastTransactionWithRequest:(BroadcastTransactionRequest *)request handler:(void(^)(BroadcastTransactionResponse *_Nullable response, NSError *_Nullable error))handler;
 
 
 #pragma mark getTransaction(GetTransactionRequest) returns (GetTransactionResponse)

--- a/clients/objective-c/Core.pbrpc.m
+++ b/clients/objective-c/Core.pbrpc.m
@@ -46,16 +46,16 @@
              responseClass:[GetBlockResponse class]
         responsesWriteable:[GRXWriteable writeableWithSingleHandler:handler]];
 }
-#pragma mark sendTransaction(SendTransactionRequest) returns (SendTransactionResponse)
+#pragma mark broadcastTransaction(BroadcastTransactionRequest) returns (BroadcastTransactionResponse)
 
-- (void)sendTransactionWithRequest:(SendTransactionRequest *)request handler:(void(^)(SendTransactionResponse *_Nullable response, NSError *_Nullable error))handler{
-  [[self RPCTosendTransactionWithRequest:request handler:handler] start];
+- (void)broadcastTransactionWithRequest:(BroadcastTransactionRequest *)request handler:(void(^)(BroadcastTransactionResponse *_Nullable response, NSError *_Nullable error))handler{
+  [[self RPCTobroadcastTransactionWithRequest:request handler:handler] start];
 }
 // Returns a not-yet-started RPC object.
-- (GRPCProtoCall *)RPCTosendTransactionWithRequest:(SendTransactionRequest *)request handler:(void(^)(SendTransactionResponse *_Nullable response, NSError *_Nullable error))handler{
-  return [self RPCToMethod:@"sendTransaction"
+- (GRPCProtoCall *)RPCTobroadcastTransactionWithRequest:(BroadcastTransactionRequest *)request handler:(void(^)(BroadcastTransactionResponse *_Nullable response, NSError *_Nullable error))handler{
+  return [self RPCToMethod:@"broadcastTransaction"
             requestsWriter:[GRXWriter writerWithValue:request]
-             responseClass:[SendTransactionResponse class]
+             responseClass:[BroadcastTransactionResponse class]
         responsesWriteable:[GRXWriteable writeableWithSingleHandler:handler]];
 }
 #pragma mark getTransaction(GetTransactionRequest) returns (GetTransactionResponse)

--- a/clients/objective-c/Platform.pbobjc.h
+++ b/clients/objective-c/Platform.pbobjc.h
@@ -44,21 +44,21 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PlatformRoot : GPBRootObject
 @end
 
-#pragma mark - ApplyStateTransitionRequest
+#pragma mark - BroadcastStateTransitionRequest
 
-typedef GPB_ENUM(ApplyStateTransitionRequest_FieldNumber) {
-  ApplyStateTransitionRequest_FieldNumber_StateTransition = 1,
+typedef GPB_ENUM(BroadcastStateTransitionRequest_FieldNumber) {
+  BroadcastStateTransitionRequest_FieldNumber_StateTransition = 1,
 };
 
-@interface ApplyStateTransitionRequest : GPBMessage
+@interface BroadcastStateTransitionRequest : GPBMessage
 
 @property(nonatomic, readwrite, copy, null_resettable) NSData *stateTransition;
 
 @end
 
-#pragma mark - ApplyStateTransitionResponse
+#pragma mark - BroadcastStateTransitionResponse
 
-@interface ApplyStateTransitionResponse : GPBMessage
+@interface BroadcastStateTransitionResponse : GPBMessage
 
 @end
 

--- a/clients/objective-c/Platform.pbobjc.m
+++ b/clients/objective-c/Platform.pbobjc.m
@@ -43,16 +43,16 @@ static GPBFileDescriptor *PlatformRoot_FileDescriptor(void) {
   return descriptor;
 }
 
-#pragma mark - ApplyStateTransitionRequest
+#pragma mark - BroadcastStateTransitionRequest
 
-@implementation ApplyStateTransitionRequest
+@implementation BroadcastStateTransitionRequest
 
 @dynamic stateTransition;
 
-typedef struct ApplyStateTransitionRequest__storage_ {
+typedef struct BroadcastStateTransitionRequest__storage_ {
   uint32_t _has_storage_[1];
   NSData *stateTransition;
-} ApplyStateTransitionRequest__storage_;
+} BroadcastStateTransitionRequest__storage_;
 
 // This method is threadsafe because it is initially called
 // in +initialize for each subclass.
@@ -63,20 +63,20 @@ typedef struct ApplyStateTransitionRequest__storage_ {
       {
         .name = "stateTransition",
         .dataTypeSpecific.className = NULL,
-        .number = ApplyStateTransitionRequest_FieldNumber_StateTransition,
+        .number = BroadcastStateTransitionRequest_FieldNumber_StateTransition,
         .hasIndex = 0,
-        .offset = (uint32_t)offsetof(ApplyStateTransitionRequest__storage_, stateTransition),
+        .offset = (uint32_t)offsetof(BroadcastStateTransitionRequest__storage_, stateTransition),
         .flags = GPBFieldOptional,
         .dataType = GPBDataTypeBytes,
       },
     };
     GPBDescriptor *localDescriptor =
-        [GPBDescriptor allocDescriptorForClass:[ApplyStateTransitionRequest class]
+        [GPBDescriptor allocDescriptorForClass:[BroadcastStateTransitionRequest class]
                                      rootClass:[PlatformRoot class]
                                           file:PlatformRoot_FileDescriptor()
                                         fields:fields
                                     fieldCount:(uint32_t)(sizeof(fields) / sizeof(GPBMessageFieldDescription))
-                                   storageSize:sizeof(ApplyStateTransitionRequest__storage_)
+                                   storageSize:sizeof(BroadcastStateTransitionRequest__storage_)
                                          flags:GPBDescriptorInitializationFlag_None];
     NSAssert(descriptor == nil, @"Startup recursed!");
     descriptor = localDescriptor;
@@ -86,14 +86,14 @@ typedef struct ApplyStateTransitionRequest__storage_ {
 
 @end
 
-#pragma mark - ApplyStateTransitionResponse
+#pragma mark - BroadcastStateTransitionResponse
 
-@implementation ApplyStateTransitionResponse
+@implementation BroadcastStateTransitionResponse
 
 
-typedef struct ApplyStateTransitionResponse__storage_ {
+typedef struct BroadcastStateTransitionResponse__storage_ {
   uint32_t _has_storage_[1];
-} ApplyStateTransitionResponse__storage_;
+} BroadcastStateTransitionResponse__storage_;
 
 // This method is threadsafe because it is initially called
 // in +initialize for each subclass.
@@ -101,12 +101,12 @@ typedef struct ApplyStateTransitionResponse__storage_ {
   static GPBDescriptor *descriptor = nil;
   if (!descriptor) {
     GPBDescriptor *localDescriptor =
-        [GPBDescriptor allocDescriptorForClass:[ApplyStateTransitionResponse class]
+        [GPBDescriptor allocDescriptorForClass:[BroadcastStateTransitionResponse class]
                                      rootClass:[PlatformRoot class]
                                           file:PlatformRoot_FileDescriptor()
                                         fields:NULL
                                     fieldCount:0
-                                   storageSize:sizeof(ApplyStateTransitionResponse__storage_)
+                                   storageSize:sizeof(BroadcastStateTransitionResponse__storage_)
                                          flags:GPBDescriptorInitializationFlag_None];
     NSAssert(descriptor == nil, @"Startup recursed!");
     descriptor = localDescriptor;

--- a/clients/objective-c/Platform.pbrpc.h
+++ b/clients/objective-c/Platform.pbrpc.h
@@ -11,11 +11,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol Platform <NSObject>
 
-#pragma mark applyStateTransition(ApplyStateTransitionRequest) returns (ApplyStateTransitionResponse)
+#pragma mark broadcastStateTransition(BroadcastStateTransitionRequest) returns (BroadcastStateTransitionResponse)
 
-- (void)applyStateTransitionWithRequest:(ApplyStateTransitionRequest *)request handler:(void(^)(ApplyStateTransitionResponse *_Nullable response, NSError *_Nullable error))handler;
+- (void)broadcastStateTransitionWithRequest:(BroadcastStateTransitionRequest *)request handler:(void(^)(BroadcastStateTransitionResponse *_Nullable response, NSError *_Nullable error))handler;
 
-- (GRPCProtoCall *)RPCToapplyStateTransitionWithRequest:(ApplyStateTransitionRequest *)request handler:(void(^)(ApplyStateTransitionResponse *_Nullable response, NSError *_Nullable error))handler;
+- (GRPCProtoCall *)RPCTobroadcastStateTransitionWithRequest:(BroadcastStateTransitionRequest *)request handler:(void(^)(BroadcastStateTransitionResponse *_Nullable response, NSError *_Nullable error))handler;
 
 
 #pragma mark getIdentity(GetIdentityRequest) returns (GetIdentityResponse)

--- a/clients/objective-c/Platform.pbrpc.m
+++ b/clients/objective-c/Platform.pbrpc.m
@@ -22,16 +22,16 @@
 }
 
 
-#pragma mark applyStateTransition(ApplyStateTransitionRequest) returns (ApplyStateTransitionResponse)
+#pragma mark broadcastStateTransition(BroadcastStateTransitionRequest) returns (BroadcastStateTransitionResponse)
 
-- (void)applyStateTransitionWithRequest:(ApplyStateTransitionRequest *)request handler:(void(^)(ApplyStateTransitionResponse *_Nullable response, NSError *_Nullable error))handler{
-  [[self RPCToapplyStateTransitionWithRequest:request handler:handler] start];
+- (void)broadcastStateTransitionWithRequest:(BroadcastStateTransitionRequest *)request handler:(void(^)(BroadcastStateTransitionResponse *_Nullable response, NSError *_Nullable error))handler{
+  [[self RPCTobroadcastStateTransitionWithRequest:request handler:handler] start];
 }
 // Returns a not-yet-started RPC object.
-- (GRPCProtoCall *)RPCToapplyStateTransitionWithRequest:(ApplyStateTransitionRequest *)request handler:(void(^)(ApplyStateTransitionResponse *_Nullable response, NSError *_Nullable error))handler{
-  return [self RPCToMethod:@"applyStateTransition"
+- (GRPCProtoCall *)RPCTobroadcastStateTransitionWithRequest:(BroadcastStateTransitionRequest *)request handler:(void(^)(BroadcastStateTransitionResponse *_Nullable response, NSError *_Nullable error))handler{
+  return [self RPCToMethod:@"broadcastStateTransition"
             requestsWriter:[GRXWriter writerWithValue:request]
-             responseClass:[ApplyStateTransitionResponse class]
+             responseClass:[BroadcastStateTransitionResponse class]
         responsesWriteable:[GRXWriteable writeableWithSingleHandler:handler]];
 }
 #pragma mark getIdentity(GetIdentityRequest) returns (GetIdentityResponse)

--- a/clients/python/core_pb2.py
+++ b/clients/python/core_pb2.py
@@ -19,7 +19,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='core.proto',
   package='org.dash.platform.dapi.v0',
   syntax='proto3',
-  serialized_pb=_b('\n\ncore.proto\x12\x19org.dash.platform.dapi.v0\"\x12\n\x10GetStatusRequest\"\xe5\x01\n\x11GetStatusResponse\x12\x14\n\x0c\x63ore_version\x18\x01 \x01(\r\x12\x18\n\x10protocol_version\x18\x02 \x01(\r\x12\x0e\n\x06\x62locks\x18\x03 \x01(\r\x12\x13\n\x0btime_offset\x18\x04 \x01(\r\x12\x13\n\x0b\x63onnections\x18\x05 \x01(\r\x12\r\n\x05proxy\x18\x06 \x01(\t\x12\x12\n\ndifficulty\x18\x07 \x01(\x01\x12\x0f\n\x07testnet\x18\x08 \x01(\x08\x12\x11\n\trelay_fee\x18\t \x01(\x01\x12\x0e\n\x06\x65rrors\x18\n \x01(\t\x12\x0f\n\x07network\x18\x0b \x01(\t\"<\n\x0fGetBlockRequest\x12\x10\n\x06height\x18\x01 \x01(\rH\x00\x12\x0e\n\x04hash\x18\x02 \x01(\tH\x00\x42\x07\n\x05\x62lock\"!\n\x10GetBlockResponse\x12\r\n\x05\x62lock\x18\x01 \x01(\x0c\"]\n\x16SendTransactionRequest\x12\x13\n\x0btransaction\x18\x01 \x01(\x0c\x12\x17\n\x0f\x61llow_high_fees\x18\x02 \x01(\x08\x12\x15\n\rbypass_limits\x18\x03 \x01(\x08\"1\n\x17SendTransactionResponse\x12\x16\n\x0etransaction_id\x18\x01 \x01(\t\"#\n\x15GetTransactionRequest\x12\n\n\x02id\x18\x01 \x01(\t\"-\n\x16GetTransactionResponse\x12\x13\n\x0btransaction\x18\x01 \x01(\x0c\"x\n!BlockHeadersWithChainLocksRequest\x12\x19\n\x0f\x66rom_block_hash\x18\x01 \x01(\x0cH\x00\x12\x1b\n\x11\x66rom_block_height\x18\x02 \x01(\rH\x00\x12\r\n\x05\x63ount\x18\x03 \x01(\rB\x0c\n\nfrom_block\"\xd3\x01\n\"BlockHeadersWithChainLocksResponse\x12@\n\rblock_headers\x18\x01 \x01(\x0b\x32\'.org.dash.platform.dapi.v0.BlockHeadersH\x00\x12^\n\x1d\x63hain_lock_signature_messages\x18\x02 \x01(\x0b\x32\x35.org.dash.platform.dapi.v0.ChainLockSignatureMessagesH\x00\x42\x0b\n\tresponses\"\x1f\n\x0c\x42lockHeaders\x12\x0f\n\x07headers\x18\x01 \x03(\x0c\".\n\x1a\x43hainLockSignatureMessages\x12\x10\n\x08messages\x18\x01 \x03(\x0c\"3\n!GetEstimatedTransactionFeeRequest\x12\x0e\n\x06\x62locks\x18\x01 \x01(\r\"1\n\"GetEstimatedTransactionFeeResponse\x12\x0b\n\x03\x66\x65\x65\x18\x01 \x01(\x01\x32\x89\x06\n\x04\x43ore\x12\x66\n\tgetStatus\x12+.org.dash.platform.dapi.v0.GetStatusRequest\x1a,.org.dash.platform.dapi.v0.GetStatusResponse\x12\x63\n\x08getBlock\x12*.org.dash.platform.dapi.v0.GetBlockRequest\x1a+.org.dash.platform.dapi.v0.GetBlockResponse\x12x\n\x0fsendTransaction\x12\x31.org.dash.platform.dapi.v0.SendTransactionRequest\x1a\x32.org.dash.platform.dapi.v0.SendTransactionResponse\x12u\n\x0egetTransaction\x12\x30.org.dash.platform.dapi.v0.GetTransactionRequest\x1a\x31.org.dash.platform.dapi.v0.GetTransactionResponse\x12\x99\x01\n\x1agetEstimatedTransactionFee\x12<.org.dash.platform.dapi.v0.GetEstimatedTransactionFeeRequest\x1a=.org.dash.platform.dapi.v0.GetEstimatedTransactionFeeResponse\x12\xa6\x01\n%subscribeToBlockHeadersWithChainLocks\x12<.org.dash.platform.dapi.v0.BlockHeadersWithChainLocksRequest\x1a=.org.dash.platform.dapi.v0.BlockHeadersWithChainLocksResponse0\x01\x62\x06proto3')
+  serialized_pb=_b('\n\ncore.proto\x12\x19org.dash.platform.dapi.v0\"\x12\n\x10GetStatusRequest\"\xe5\x01\n\x11GetStatusResponse\x12\x14\n\x0c\x63ore_version\x18\x01 \x01(\r\x12\x18\n\x10protocol_version\x18\x02 \x01(\r\x12\x0e\n\x06\x62locks\x18\x03 \x01(\r\x12\x13\n\x0btime_offset\x18\x04 \x01(\r\x12\x13\n\x0b\x63onnections\x18\x05 \x01(\r\x12\r\n\x05proxy\x18\x06 \x01(\t\x12\x12\n\ndifficulty\x18\x07 \x01(\x01\x12\x0f\n\x07testnet\x18\x08 \x01(\x08\x12\x11\n\trelay_fee\x18\t \x01(\x01\x12\x0e\n\x06\x65rrors\x18\n \x01(\t\x12\x0f\n\x07network\x18\x0b \x01(\t\"<\n\x0fGetBlockRequest\x12\x10\n\x06height\x18\x01 \x01(\rH\x00\x12\x0e\n\x04hash\x18\x02 \x01(\tH\x00\x42\x07\n\x05\x62lock\"!\n\x10GetBlockResponse\x12\r\n\x05\x62lock\x18\x01 \x01(\x0c\"b\n\x1b\x42roadcastTransactionRequest\x12\x13\n\x0btransaction\x18\x01 \x01(\x0c\x12\x17\n\x0f\x61llow_high_fees\x18\x02 \x01(\x08\x12\x15\n\rbypass_limits\x18\x03 \x01(\x08\"6\n\x1c\x42roadcastTransactionResponse\x12\x16\n\x0etransaction_id\x18\x01 \x01(\t\"#\n\x15GetTransactionRequest\x12\n\n\x02id\x18\x01 \x01(\t\"-\n\x16GetTransactionResponse\x12\x13\n\x0btransaction\x18\x01 \x01(\x0c\"x\n!BlockHeadersWithChainLocksRequest\x12\x19\n\x0f\x66rom_block_hash\x18\x01 \x01(\x0cH\x00\x12\x1b\n\x11\x66rom_block_height\x18\x02 \x01(\rH\x00\x12\r\n\x05\x63ount\x18\x03 \x01(\rB\x0c\n\nfrom_block\"\xd3\x01\n\"BlockHeadersWithChainLocksResponse\x12@\n\rblock_headers\x18\x01 \x01(\x0b\x32\'.org.dash.platform.dapi.v0.BlockHeadersH\x00\x12^\n\x1d\x63hain_lock_signature_messages\x18\x02 \x01(\x0b\x32\x35.org.dash.platform.dapi.v0.ChainLockSignatureMessagesH\x00\x42\x0b\n\tresponses\"\x1f\n\x0c\x42lockHeaders\x12\x0f\n\x07headers\x18\x01 \x03(\x0c\".\n\x1a\x43hainLockSignatureMessages\x12\x10\n\x08messages\x18\x01 \x03(\x0c\"3\n!GetEstimatedTransactionFeeRequest\x12\x0e\n\x06\x62locks\x18\x01 \x01(\r\"1\n\"GetEstimatedTransactionFeeResponse\x12\x0b\n\x03\x66\x65\x65\x18\x01 \x01(\x01\x32\x99\x06\n\x04\x43ore\x12\x66\n\tgetStatus\x12+.org.dash.platform.dapi.v0.GetStatusRequest\x1a,.org.dash.platform.dapi.v0.GetStatusResponse\x12\x63\n\x08getBlock\x12*.org.dash.platform.dapi.v0.GetBlockRequest\x1a+.org.dash.platform.dapi.v0.GetBlockResponse\x12\x87\x01\n\x14\x62roadcastTransaction\x12\x36.org.dash.platform.dapi.v0.BroadcastTransactionRequest\x1a\x37.org.dash.platform.dapi.v0.BroadcastTransactionResponse\x12u\n\x0egetTransaction\x12\x30.org.dash.platform.dapi.v0.GetTransactionRequest\x1a\x31.org.dash.platform.dapi.v0.GetTransactionResponse\x12\x99\x01\n\x1agetEstimatedTransactionFee\x12<.org.dash.platform.dapi.v0.GetEstimatedTransactionFeeRequest\x1a=.org.dash.platform.dapi.v0.GetEstimatedTransactionFeeResponse\x12\xa6\x01\n%subscribeToBlockHeadersWithChainLocks\x12<.org.dash.platform.dapi.v0.BlockHeadersWithChainLocksRequest\x1a=.org.dash.platform.dapi.v0.BlockHeadersWithChainLocksResponse0\x01\x62\x06proto3')
 )
 
 
@@ -222,29 +222,29 @@ _GETBLOCKRESPONSE = _descriptor.Descriptor(
 )
 
 
-_SENDTRANSACTIONREQUEST = _descriptor.Descriptor(
-  name='SendTransactionRequest',
-  full_name='org.dash.platform.dapi.v0.SendTransactionRequest',
+_BROADCASTTRANSACTIONREQUEST = _descriptor.Descriptor(
+  name='BroadcastTransactionRequest',
+  full_name='org.dash.platform.dapi.v0.BroadcastTransactionRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='transaction', full_name='org.dash.platform.dapi.v0.SendTransactionRequest.transaction', index=0,
+      name='transaction', full_name='org.dash.platform.dapi.v0.BroadcastTransactionRequest.transaction', index=0,
       number=1, type=12, cpp_type=9, label=1,
       has_default_value=False, default_value=_b(""),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='allow_high_fees', full_name='org.dash.platform.dapi.v0.SendTransactionRequest.allow_high_fees', index=1,
+      name='allow_high_fees', full_name='org.dash.platform.dapi.v0.BroadcastTransactionRequest.allow_high_fees', index=1,
       number=2, type=8, cpp_type=7, label=1,
       has_default_value=False, default_value=False,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='bypass_limits', full_name='org.dash.platform.dapi.v0.SendTransactionRequest.bypass_limits', index=2,
+      name='bypass_limits', full_name='org.dash.platform.dapi.v0.BroadcastTransactionRequest.bypass_limits', index=2,
       number=3, type=8, cpp_type=7, label=1,
       has_default_value=False, default_value=False,
       message_type=None, enum_type=None, containing_type=None,
@@ -263,19 +263,19 @@ _SENDTRANSACTIONREQUEST = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=390,
-  serialized_end=483,
+  serialized_end=488,
 )
 
 
-_SENDTRANSACTIONRESPONSE = _descriptor.Descriptor(
-  name='SendTransactionResponse',
-  full_name='org.dash.platform.dapi.v0.SendTransactionResponse',
+_BROADCASTTRANSACTIONRESPONSE = _descriptor.Descriptor(
+  name='BroadcastTransactionResponse',
+  full_name='org.dash.platform.dapi.v0.BroadcastTransactionResponse',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='transaction_id', full_name='org.dash.platform.dapi.v0.SendTransactionResponse.transaction_id', index=0,
+      name='transaction_id', full_name='org.dash.platform.dapi.v0.BroadcastTransactionResponse.transaction_id', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -293,8 +293,8 @@ _SENDTRANSACTIONRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=485,
-  serialized_end=534,
+  serialized_start=490,
+  serialized_end=544,
 )
 
 
@@ -324,8 +324,8 @@ _GETTRANSACTIONREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=536,
-  serialized_end=571,
+  serialized_start=546,
+  serialized_end=581,
 )
 
 
@@ -355,8 +355,8 @@ _GETTRANSACTIONRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=573,
-  serialized_end=618,
+  serialized_start=583,
+  serialized_end=628,
 )
 
 
@@ -403,8 +403,8 @@ _BLOCKHEADERSWITHCHAINLOCKSREQUEST = _descriptor.Descriptor(
       name='from_block', full_name='org.dash.platform.dapi.v0.BlockHeadersWithChainLocksRequest.from_block',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=620,
-  serialized_end=740,
+  serialized_start=630,
+  serialized_end=750,
 )
 
 
@@ -444,8 +444,8 @@ _BLOCKHEADERSWITHCHAINLOCKSRESPONSE = _descriptor.Descriptor(
       name='responses', full_name='org.dash.platform.dapi.v0.BlockHeadersWithChainLocksResponse.responses',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=743,
-  serialized_end=954,
+  serialized_start=753,
+  serialized_end=964,
 )
 
 
@@ -475,8 +475,8 @@ _BLOCKHEADERS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=956,
-  serialized_end=987,
+  serialized_start=966,
+  serialized_end=997,
 )
 
 
@@ -506,8 +506,8 @@ _CHAINLOCKSIGNATUREMESSAGES = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=989,
-  serialized_end=1035,
+  serialized_start=999,
+  serialized_end=1045,
 )
 
 
@@ -537,8 +537,8 @@ _GETESTIMATEDTRANSACTIONFEEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1037,
-  serialized_end=1088,
+  serialized_start=1047,
+  serialized_end=1098,
 )
 
 
@@ -568,8 +568,8 @@ _GETESTIMATEDTRANSACTIONFEERESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1090,
-  serialized_end=1139,
+  serialized_start=1100,
+  serialized_end=1149,
 )
 
 _GETBLOCKREQUEST.oneofs_by_name['block'].fields.append(
@@ -596,8 +596,8 @@ DESCRIPTOR.message_types_by_name['GetStatusRequest'] = _GETSTATUSREQUEST
 DESCRIPTOR.message_types_by_name['GetStatusResponse'] = _GETSTATUSRESPONSE
 DESCRIPTOR.message_types_by_name['GetBlockRequest'] = _GETBLOCKREQUEST
 DESCRIPTOR.message_types_by_name['GetBlockResponse'] = _GETBLOCKRESPONSE
-DESCRIPTOR.message_types_by_name['SendTransactionRequest'] = _SENDTRANSACTIONREQUEST
-DESCRIPTOR.message_types_by_name['SendTransactionResponse'] = _SENDTRANSACTIONRESPONSE
+DESCRIPTOR.message_types_by_name['BroadcastTransactionRequest'] = _BROADCASTTRANSACTIONREQUEST
+DESCRIPTOR.message_types_by_name['BroadcastTransactionResponse'] = _BROADCASTTRANSACTIONRESPONSE
 DESCRIPTOR.message_types_by_name['GetTransactionRequest'] = _GETTRANSACTIONREQUEST
 DESCRIPTOR.message_types_by_name['GetTransactionResponse'] = _GETTRANSACTIONRESPONSE
 DESCRIPTOR.message_types_by_name['BlockHeadersWithChainLocksRequest'] = _BLOCKHEADERSWITHCHAINLOCKSREQUEST
@@ -636,19 +636,19 @@ GetBlockResponse = _reflection.GeneratedProtocolMessageType('GetBlockResponse', 
   ))
 _sym_db.RegisterMessage(GetBlockResponse)
 
-SendTransactionRequest = _reflection.GeneratedProtocolMessageType('SendTransactionRequest', (_message.Message,), dict(
-  DESCRIPTOR = _SENDTRANSACTIONREQUEST,
+BroadcastTransactionRequest = _reflection.GeneratedProtocolMessageType('BroadcastTransactionRequest', (_message.Message,), dict(
+  DESCRIPTOR = _BROADCASTTRANSACTIONREQUEST,
   __module__ = 'core_pb2'
-  # @@protoc_insertion_point(class_scope:org.dash.platform.dapi.v0.SendTransactionRequest)
+  # @@protoc_insertion_point(class_scope:org.dash.platform.dapi.v0.BroadcastTransactionRequest)
   ))
-_sym_db.RegisterMessage(SendTransactionRequest)
+_sym_db.RegisterMessage(BroadcastTransactionRequest)
 
-SendTransactionResponse = _reflection.GeneratedProtocolMessageType('SendTransactionResponse', (_message.Message,), dict(
-  DESCRIPTOR = _SENDTRANSACTIONRESPONSE,
+BroadcastTransactionResponse = _reflection.GeneratedProtocolMessageType('BroadcastTransactionResponse', (_message.Message,), dict(
+  DESCRIPTOR = _BROADCASTTRANSACTIONRESPONSE,
   __module__ = 'core_pb2'
-  # @@protoc_insertion_point(class_scope:org.dash.platform.dapi.v0.SendTransactionResponse)
+  # @@protoc_insertion_point(class_scope:org.dash.platform.dapi.v0.BroadcastTransactionResponse)
   ))
-_sym_db.RegisterMessage(SendTransactionResponse)
+_sym_db.RegisterMessage(BroadcastTransactionResponse)
 
 GetTransactionRequest = _reflection.GeneratedProtocolMessageType('GetTransactionRequest', (_message.Message,), dict(
   DESCRIPTOR = _GETTRANSACTIONREQUEST,
@@ -714,8 +714,8 @@ _CORE = _descriptor.ServiceDescriptor(
   file=DESCRIPTOR,
   index=0,
   options=None,
-  serialized_start=1142,
-  serialized_end=1919,
+  serialized_start=1152,
+  serialized_end=1945,
   methods=[
   _descriptor.MethodDescriptor(
     name='getStatus',
@@ -736,12 +736,12 @@ _CORE = _descriptor.ServiceDescriptor(
     options=None,
   ),
   _descriptor.MethodDescriptor(
-    name='sendTransaction',
-    full_name='org.dash.platform.dapi.v0.Core.sendTransaction',
+    name='broadcastTransaction',
+    full_name='org.dash.platform.dapi.v0.Core.broadcastTransaction',
     index=2,
     containing_service=None,
-    input_type=_SENDTRANSACTIONREQUEST,
-    output_type=_SENDTRANSACTIONRESPONSE,
+    input_type=_BROADCASTTRANSACTIONREQUEST,
+    output_type=_BROADCASTTRANSACTIONRESPONSE,
     options=None,
   ),
   _descriptor.MethodDescriptor(
@@ -806,10 +806,10 @@ try:
           request_serializer=GetBlockRequest.SerializeToString,
           response_deserializer=GetBlockResponse.FromString,
           )
-      self.sendTransaction = channel.unary_unary(
-          '/org.dash.platform.dapi.v0.Core/sendTransaction',
-          request_serializer=SendTransactionRequest.SerializeToString,
-          response_deserializer=SendTransactionResponse.FromString,
+      self.broadcastTransaction = channel.unary_unary(
+          '/org.dash.platform.dapi.v0.Core/broadcastTransaction',
+          request_serializer=BroadcastTransactionRequest.SerializeToString,
+          response_deserializer=BroadcastTransactionResponse.FromString,
           )
       self.getTransaction = channel.unary_unary(
           '/org.dash.platform.dapi.v0.Core/getTransaction',
@@ -846,7 +846,7 @@ try:
       context.set_details('Method not implemented!')
       raise NotImplementedError('Method not implemented!')
 
-    def sendTransaction(self, request, context):
+    def broadcastTransaction(self, request, context):
       # missing associated documentation comment in .proto file
       pass
       context.set_code(grpc.StatusCode.UNIMPLEMENTED)
@@ -887,10 +887,10 @@ try:
             request_deserializer=GetBlockRequest.FromString,
             response_serializer=GetBlockResponse.SerializeToString,
         ),
-        'sendTransaction': grpc.unary_unary_rpc_method_handler(
-            servicer.sendTransaction,
-            request_deserializer=SendTransactionRequest.FromString,
-            response_serializer=SendTransactionResponse.SerializeToString,
+        'broadcastTransaction': grpc.unary_unary_rpc_method_handler(
+            servicer.broadcastTransaction,
+            request_deserializer=BroadcastTransactionRequest.FromString,
+            response_serializer=BroadcastTransactionResponse.SerializeToString,
         ),
         'getTransaction': grpc.unary_unary_rpc_method_handler(
             servicer.getTransaction,
@@ -929,7 +929,7 @@ try:
       # missing associated documentation comment in .proto file
       pass
       context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
-    def sendTransaction(self, request, context):
+    def broadcastTransaction(self, request, context):
       # missing associated documentation comment in .proto file
       pass
       context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
@@ -965,11 +965,11 @@ try:
       pass
       raise NotImplementedError()
     getBlock.future = None
-    def sendTransaction(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
+    def broadcastTransaction(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
       # missing associated documentation comment in .proto file
       pass
       raise NotImplementedError()
-    sendTransaction.future = None
+    broadcastTransaction.future = None
     def getTransaction(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
       # missing associated documentation comment in .proto file
       pass
@@ -993,27 +993,27 @@ try:
     file not marked beta) for all further purposes. This function was
     generated only to ease transition from grpcio<0.15.0 to grpcio>=0.15.0"""
     request_deserializers = {
+      ('org.dash.platform.dapi.v0.Core', 'broadcastTransaction'): BroadcastTransactionRequest.FromString,
       ('org.dash.platform.dapi.v0.Core', 'getBlock'): GetBlockRequest.FromString,
       ('org.dash.platform.dapi.v0.Core', 'getEstimatedTransactionFee'): GetEstimatedTransactionFeeRequest.FromString,
       ('org.dash.platform.dapi.v0.Core', 'getStatus'): GetStatusRequest.FromString,
       ('org.dash.platform.dapi.v0.Core', 'getTransaction'): GetTransactionRequest.FromString,
-      ('org.dash.platform.dapi.v0.Core', 'sendTransaction'): SendTransactionRequest.FromString,
       ('org.dash.platform.dapi.v0.Core', 'subscribeToBlockHeadersWithChainLocks'): BlockHeadersWithChainLocksRequest.FromString,
     }
     response_serializers = {
+      ('org.dash.platform.dapi.v0.Core', 'broadcastTransaction'): BroadcastTransactionResponse.SerializeToString,
       ('org.dash.platform.dapi.v0.Core', 'getBlock'): GetBlockResponse.SerializeToString,
       ('org.dash.platform.dapi.v0.Core', 'getEstimatedTransactionFee'): GetEstimatedTransactionFeeResponse.SerializeToString,
       ('org.dash.platform.dapi.v0.Core', 'getStatus'): GetStatusResponse.SerializeToString,
       ('org.dash.platform.dapi.v0.Core', 'getTransaction'): GetTransactionResponse.SerializeToString,
-      ('org.dash.platform.dapi.v0.Core', 'sendTransaction'): SendTransactionResponse.SerializeToString,
       ('org.dash.platform.dapi.v0.Core', 'subscribeToBlockHeadersWithChainLocks'): BlockHeadersWithChainLocksResponse.SerializeToString,
     }
     method_implementations = {
+      ('org.dash.platform.dapi.v0.Core', 'broadcastTransaction'): face_utilities.unary_unary_inline(servicer.broadcastTransaction),
       ('org.dash.platform.dapi.v0.Core', 'getBlock'): face_utilities.unary_unary_inline(servicer.getBlock),
       ('org.dash.platform.dapi.v0.Core', 'getEstimatedTransactionFee'): face_utilities.unary_unary_inline(servicer.getEstimatedTransactionFee),
       ('org.dash.platform.dapi.v0.Core', 'getStatus'): face_utilities.unary_unary_inline(servicer.getStatus),
       ('org.dash.platform.dapi.v0.Core', 'getTransaction'): face_utilities.unary_unary_inline(servicer.getTransaction),
-      ('org.dash.platform.dapi.v0.Core', 'sendTransaction'): face_utilities.unary_unary_inline(servicer.sendTransaction),
       ('org.dash.platform.dapi.v0.Core', 'subscribeToBlockHeadersWithChainLocks'): face_utilities.unary_stream_inline(servicer.subscribeToBlockHeadersWithChainLocks),
     }
     server_options = beta_implementations.server_options(request_deserializers=request_deserializers, response_serializers=response_serializers, thread_pool=pool, thread_pool_size=pool_size, default_timeout=default_timeout, maximum_timeout=maximum_timeout)
@@ -1027,27 +1027,27 @@ try:
     file not marked beta) for all further purposes. This function was
     generated only to ease transition from grpcio<0.15.0 to grpcio>=0.15.0"""
     request_serializers = {
+      ('org.dash.platform.dapi.v0.Core', 'broadcastTransaction'): BroadcastTransactionRequest.SerializeToString,
       ('org.dash.platform.dapi.v0.Core', 'getBlock'): GetBlockRequest.SerializeToString,
       ('org.dash.platform.dapi.v0.Core', 'getEstimatedTransactionFee'): GetEstimatedTransactionFeeRequest.SerializeToString,
       ('org.dash.platform.dapi.v0.Core', 'getStatus'): GetStatusRequest.SerializeToString,
       ('org.dash.platform.dapi.v0.Core', 'getTransaction'): GetTransactionRequest.SerializeToString,
-      ('org.dash.platform.dapi.v0.Core', 'sendTransaction'): SendTransactionRequest.SerializeToString,
       ('org.dash.platform.dapi.v0.Core', 'subscribeToBlockHeadersWithChainLocks'): BlockHeadersWithChainLocksRequest.SerializeToString,
     }
     response_deserializers = {
+      ('org.dash.platform.dapi.v0.Core', 'broadcastTransaction'): BroadcastTransactionResponse.FromString,
       ('org.dash.platform.dapi.v0.Core', 'getBlock'): GetBlockResponse.FromString,
       ('org.dash.platform.dapi.v0.Core', 'getEstimatedTransactionFee'): GetEstimatedTransactionFeeResponse.FromString,
       ('org.dash.platform.dapi.v0.Core', 'getStatus'): GetStatusResponse.FromString,
       ('org.dash.platform.dapi.v0.Core', 'getTransaction'): GetTransactionResponse.FromString,
-      ('org.dash.platform.dapi.v0.Core', 'sendTransaction'): SendTransactionResponse.FromString,
       ('org.dash.platform.dapi.v0.Core', 'subscribeToBlockHeadersWithChainLocks'): BlockHeadersWithChainLocksResponse.FromString,
     }
     cardinalities = {
+      'broadcastTransaction': cardinality.Cardinality.UNARY_UNARY,
       'getBlock': cardinality.Cardinality.UNARY_UNARY,
       'getEstimatedTransactionFee': cardinality.Cardinality.UNARY_UNARY,
       'getStatus': cardinality.Cardinality.UNARY_UNARY,
       'getTransaction': cardinality.Cardinality.UNARY_UNARY,
-      'sendTransaction': cardinality.Cardinality.UNARY_UNARY,
       'subscribeToBlockHeadersWithChainLocks': cardinality.Cardinality.UNARY_STREAM,
     }
     stub_options = beta_implementations.stub_options(host=host, metadata_transformer=metadata_transformer, request_serializers=request_serializers, response_deserializers=response_deserializers, thread_pool=pool, thread_pool_size=pool_size)

--- a/clients/python/core_pb2_grpc.py
+++ b/clients/python/core_pb2_grpc.py
@@ -24,10 +24,10 @@ class CoreStub(object):
         request_serializer=core__pb2.GetBlockRequest.SerializeToString,
         response_deserializer=core__pb2.GetBlockResponse.FromString,
         )
-    self.sendTransaction = channel.unary_unary(
-        '/org.dash.platform.dapi.v0.Core/sendTransaction',
-        request_serializer=core__pb2.SendTransactionRequest.SerializeToString,
-        response_deserializer=core__pb2.SendTransactionResponse.FromString,
+    self.broadcastTransaction = channel.unary_unary(
+        '/org.dash.platform.dapi.v0.Core/broadcastTransaction',
+        request_serializer=core__pb2.BroadcastTransactionRequest.SerializeToString,
+        response_deserializer=core__pb2.BroadcastTransactionResponse.FromString,
         )
     self.getTransaction = channel.unary_unary(
         '/org.dash.platform.dapi.v0.Core/getTransaction',
@@ -64,7 +64,7 @@ class CoreServicer(object):
     context.set_details('Method not implemented!')
     raise NotImplementedError('Method not implemented!')
 
-  def sendTransaction(self, request, context):
+  def broadcastTransaction(self, request, context):
     # missing associated documentation comment in .proto file
     pass
     context.set_code(grpc.StatusCode.UNIMPLEMENTED)
@@ -105,10 +105,10 @@ def add_CoreServicer_to_server(servicer, server):
           request_deserializer=core__pb2.GetBlockRequest.FromString,
           response_serializer=core__pb2.GetBlockResponse.SerializeToString,
       ),
-      'sendTransaction': grpc.unary_unary_rpc_method_handler(
-          servicer.sendTransaction,
-          request_deserializer=core__pb2.SendTransactionRequest.FromString,
-          response_serializer=core__pb2.SendTransactionResponse.SerializeToString,
+      'broadcastTransaction': grpc.unary_unary_rpc_method_handler(
+          servicer.broadcastTransaction,
+          request_deserializer=core__pb2.BroadcastTransactionRequest.FromString,
+          response_serializer=core__pb2.BroadcastTransactionResponse.SerializeToString,
       ),
       'getTransaction': grpc.unary_unary_rpc_method_handler(
           servicer.getTransaction,

--- a/clients/python/platform_pb2.py
+++ b/clients/python/platform_pb2.py
@@ -19,21 +19,21 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='platform.proto',
   package='org.dash.platform.dapi.v0',
   syntax='proto3',
-  serialized_pb=_b('\n\x0eplatform.proto\x12\x19org.dash.platform.dapi.v0\"7\n\x1b\x41pplyStateTransitionRequest\x12\x18\n\x10state_transition\x18\x01 \x01(\x0c\"\x1e\n\x1c\x41pplyStateTransitionResponse\" \n\x12GetIdentityRequest\x12\n\n\x02id\x18\x01 \x01(\t\"\'\n\x13GetIdentityResponse\x12\x10\n\x08identity\x18\x01 \x01(\x0c\"$\n\x16GetDataContractRequest\x12\n\n\x02id\x18\x01 \x01(\t\"0\n\x17GetDataContractResponse\x12\x15\n\rdata_contract\x18\x01 \x01(\x0c\"\xaa\x01\n\x13GetDocumentsRequest\x12\x18\n\x10\x64\x61ta_contract_id\x18\x01 \x01(\t\x12\x15\n\rdocument_type\x18\x02 \x01(\t\x12\r\n\x05where\x18\x03 \x01(\x0c\x12\x10\n\x08order_by\x18\x04 \x01(\x0c\x12\r\n\x05limit\x18\x05 \x01(\r\x12\x15\n\x0bstart_after\x18\x06 \x01(\rH\x00\x12\x12\n\x08start_at\x18\x07 \x01(\rH\x00\x42\x07\n\x05start\")\n\x14GetDocumentsResponse\x12\x11\n\tdocuments\x18\x01 \x03(\x0c\"=\n\"GetIdentityByFirstPublicKeyRequest\x12\x17\n\x0fpublic_key_hash\x18\x01 \x01(\x0c\"7\n#GetIdentityByFirstPublicKeyResponse\x12\x10\n\x08identity\x18\x01 \x01(\x0c\"?\n$GetIdentityIdByFirstPublicKeyRequest\x12\x17\n\x0fpublic_key_hash\x18\x01 \x01(\x0c\"3\n%GetIdentityIdByFirstPublicKeyResponse\x12\n\n\x02id\x18\x01 \x01(\t2\xb1\x06\n\x08Platform\x12\x87\x01\n\x14\x61pplyStateTransition\x12\x36.org.dash.platform.dapi.v0.ApplyStateTransitionRequest\x1a\x37.org.dash.platform.dapi.v0.ApplyStateTransitionResponse\x12l\n\x0bgetIdentity\x12-.org.dash.platform.dapi.v0.GetIdentityRequest\x1a..org.dash.platform.dapi.v0.GetIdentityResponse\x12x\n\x0fgetDataContract\x12\x31.org.dash.platform.dapi.v0.GetDataContractRequest\x1a\x32.org.dash.platform.dapi.v0.GetDataContractResponse\x12o\n\x0cgetDocuments\x12..org.dash.platform.dapi.v0.GetDocumentsRequest\x1a/.org.dash.platform.dapi.v0.GetDocumentsResponse\x12\x9c\x01\n\x1bgetIdentityByFirstPublicKey\x12=.org.dash.platform.dapi.v0.GetIdentityByFirstPublicKeyRequest\x1a>.org.dash.platform.dapi.v0.GetIdentityByFirstPublicKeyResponse\x12\xa2\x01\n\x1dgetIdentityIdByFirstPublicKey\x12?.org.dash.platform.dapi.v0.GetIdentityIdByFirstPublicKeyRequest\x1a@.org.dash.platform.dapi.v0.GetIdentityIdByFirstPublicKeyResponseb\x06proto3')
+  serialized_pb=_b('\n\x0eplatform.proto\x12\x19org.dash.platform.dapi.v0\";\n\x1f\x42roadcastStateTransitionRequest\x12\x18\n\x10state_transition\x18\x01 \x01(\x0c\"\"\n BroadcastStateTransitionResponse\" \n\x12GetIdentityRequest\x12\n\n\x02id\x18\x01 \x01(\t\"\'\n\x13GetIdentityResponse\x12\x10\n\x08identity\x18\x01 \x01(\x0c\"$\n\x16GetDataContractRequest\x12\n\n\x02id\x18\x01 \x01(\t\"0\n\x17GetDataContractResponse\x12\x15\n\rdata_contract\x18\x01 \x01(\x0c\"\xaa\x01\n\x13GetDocumentsRequest\x12\x18\n\x10\x64\x61ta_contract_id\x18\x01 \x01(\t\x12\x15\n\rdocument_type\x18\x02 \x01(\t\x12\r\n\x05where\x18\x03 \x01(\x0c\x12\x10\n\x08order_by\x18\x04 \x01(\x0c\x12\r\n\x05limit\x18\x05 \x01(\r\x12\x15\n\x0bstart_after\x18\x06 \x01(\rH\x00\x12\x12\n\x08start_at\x18\x07 \x01(\rH\x00\x42\x07\n\x05start\")\n\x14GetDocumentsResponse\x12\x11\n\tdocuments\x18\x01 \x03(\x0c\"=\n\"GetIdentityByFirstPublicKeyRequest\x12\x17\n\x0fpublic_key_hash\x18\x01 \x01(\x0c\"7\n#GetIdentityByFirstPublicKeyResponse\x12\x10\n\x08identity\x18\x01 \x01(\x0c\"?\n$GetIdentityIdByFirstPublicKeyRequest\x12\x17\n\x0fpublic_key_hash\x18\x01 \x01(\x0c\"3\n%GetIdentityIdByFirstPublicKeyResponse\x12\n\n\x02id\x18\x01 \x01(\t2\xbd\x06\n\x08Platform\x12\x93\x01\n\x18\x62roadcastStateTransition\x12:.org.dash.platform.dapi.v0.BroadcastStateTransitionRequest\x1a;.org.dash.platform.dapi.v0.BroadcastStateTransitionResponse\x12l\n\x0bgetIdentity\x12-.org.dash.platform.dapi.v0.GetIdentityRequest\x1a..org.dash.platform.dapi.v0.GetIdentityResponse\x12x\n\x0fgetDataContract\x12\x31.org.dash.platform.dapi.v0.GetDataContractRequest\x1a\x32.org.dash.platform.dapi.v0.GetDataContractResponse\x12o\n\x0cgetDocuments\x12..org.dash.platform.dapi.v0.GetDocumentsRequest\x1a/.org.dash.platform.dapi.v0.GetDocumentsResponse\x12\x9c\x01\n\x1bgetIdentityByFirstPublicKey\x12=.org.dash.platform.dapi.v0.GetIdentityByFirstPublicKeyRequest\x1a>.org.dash.platform.dapi.v0.GetIdentityByFirstPublicKeyResponse\x12\xa2\x01\n\x1dgetIdentityIdByFirstPublicKey\x12?.org.dash.platform.dapi.v0.GetIdentityIdByFirstPublicKeyRequest\x1a@.org.dash.platform.dapi.v0.GetIdentityIdByFirstPublicKeyResponseb\x06proto3')
 )
 
 
 
 
-_APPLYSTATETRANSITIONREQUEST = _descriptor.Descriptor(
-  name='ApplyStateTransitionRequest',
-  full_name='org.dash.platform.dapi.v0.ApplyStateTransitionRequest',
+_BROADCASTSTATETRANSITIONREQUEST = _descriptor.Descriptor(
+  name='BroadcastStateTransitionRequest',
+  full_name='org.dash.platform.dapi.v0.BroadcastStateTransitionRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='state_transition', full_name='org.dash.platform.dapi.v0.ApplyStateTransitionRequest.state_transition', index=0,
+      name='state_transition', full_name='org.dash.platform.dapi.v0.BroadcastStateTransitionRequest.state_transition', index=0,
       number=1, type=12, cpp_type=9, label=1,
       has_default_value=False, default_value=_b(""),
       message_type=None, enum_type=None, containing_type=None,
@@ -52,13 +52,13 @@ _APPLYSTATETRANSITIONREQUEST = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=45,
-  serialized_end=100,
+  serialized_end=104,
 )
 
 
-_APPLYSTATETRANSITIONRESPONSE = _descriptor.Descriptor(
-  name='ApplyStateTransitionResponse',
-  full_name='org.dash.platform.dapi.v0.ApplyStateTransitionResponse',
+_BROADCASTSTATETRANSITIONRESPONSE = _descriptor.Descriptor(
+  name='BroadcastStateTransitionResponse',
+  full_name='org.dash.platform.dapi.v0.BroadcastStateTransitionResponse',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
@@ -75,8 +75,8 @@ _APPLYSTATETRANSITIONRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=102,
-  serialized_end=132,
+  serialized_start=106,
+  serialized_end=140,
 )
 
 
@@ -106,8 +106,8 @@ _GETIDENTITYREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=134,
-  serialized_end=166,
+  serialized_start=142,
+  serialized_end=174,
 )
 
 
@@ -137,8 +137,8 @@ _GETIDENTITYRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=168,
-  serialized_end=207,
+  serialized_start=176,
+  serialized_end=215,
 )
 
 
@@ -168,8 +168,8 @@ _GETDATACONTRACTREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=209,
-  serialized_end=245,
+  serialized_start=217,
+  serialized_end=253,
 )
 
 
@@ -199,8 +199,8 @@ _GETDATACONTRACTRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=247,
-  serialized_end=295,
+  serialized_start=255,
+  serialized_end=303,
 )
 
 
@@ -275,8 +275,8 @@ _GETDOCUMENTSREQUEST = _descriptor.Descriptor(
       name='start', full_name='org.dash.platform.dapi.v0.GetDocumentsRequest.start',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=298,
-  serialized_end=468,
+  serialized_start=306,
+  serialized_end=476,
 )
 
 
@@ -306,8 +306,8 @@ _GETDOCUMENTSRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=470,
-  serialized_end=511,
+  serialized_start=478,
+  serialized_end=519,
 )
 
 
@@ -337,8 +337,8 @@ _GETIDENTITYBYFIRSTPUBLICKEYREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=513,
-  serialized_end=574,
+  serialized_start=521,
+  serialized_end=582,
 )
 
 
@@ -368,8 +368,8 @@ _GETIDENTITYBYFIRSTPUBLICKEYRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=576,
-  serialized_end=631,
+  serialized_start=584,
+  serialized_end=639,
 )
 
 
@@ -399,8 +399,8 @@ _GETIDENTITYIDBYFIRSTPUBLICKEYREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=633,
-  serialized_end=696,
+  serialized_start=641,
+  serialized_end=704,
 )
 
 
@@ -430,8 +430,8 @@ _GETIDENTITYIDBYFIRSTPUBLICKEYRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=698,
-  serialized_end=749,
+  serialized_start=706,
+  serialized_end=757,
 )
 
 _GETDOCUMENTSREQUEST.oneofs_by_name['start'].fields.append(
@@ -440,8 +440,8 @@ _GETDOCUMENTSREQUEST.fields_by_name['start_after'].containing_oneof = _GETDOCUME
 _GETDOCUMENTSREQUEST.oneofs_by_name['start'].fields.append(
   _GETDOCUMENTSREQUEST.fields_by_name['start_at'])
 _GETDOCUMENTSREQUEST.fields_by_name['start_at'].containing_oneof = _GETDOCUMENTSREQUEST.oneofs_by_name['start']
-DESCRIPTOR.message_types_by_name['ApplyStateTransitionRequest'] = _APPLYSTATETRANSITIONREQUEST
-DESCRIPTOR.message_types_by_name['ApplyStateTransitionResponse'] = _APPLYSTATETRANSITIONRESPONSE
+DESCRIPTOR.message_types_by_name['BroadcastStateTransitionRequest'] = _BROADCASTSTATETRANSITIONREQUEST
+DESCRIPTOR.message_types_by_name['BroadcastStateTransitionResponse'] = _BROADCASTSTATETRANSITIONRESPONSE
 DESCRIPTOR.message_types_by_name['GetIdentityRequest'] = _GETIDENTITYREQUEST
 DESCRIPTOR.message_types_by_name['GetIdentityResponse'] = _GETIDENTITYRESPONSE
 DESCRIPTOR.message_types_by_name['GetDataContractRequest'] = _GETDATACONTRACTREQUEST
@@ -454,19 +454,19 @@ DESCRIPTOR.message_types_by_name['GetIdentityIdByFirstPublicKeyRequest'] = _GETI
 DESCRIPTOR.message_types_by_name['GetIdentityIdByFirstPublicKeyResponse'] = _GETIDENTITYIDBYFIRSTPUBLICKEYRESPONSE
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
-ApplyStateTransitionRequest = _reflection.GeneratedProtocolMessageType('ApplyStateTransitionRequest', (_message.Message,), dict(
-  DESCRIPTOR = _APPLYSTATETRANSITIONREQUEST,
+BroadcastStateTransitionRequest = _reflection.GeneratedProtocolMessageType('BroadcastStateTransitionRequest', (_message.Message,), dict(
+  DESCRIPTOR = _BROADCASTSTATETRANSITIONREQUEST,
   __module__ = 'platform_pb2'
-  # @@protoc_insertion_point(class_scope:org.dash.platform.dapi.v0.ApplyStateTransitionRequest)
+  # @@protoc_insertion_point(class_scope:org.dash.platform.dapi.v0.BroadcastStateTransitionRequest)
   ))
-_sym_db.RegisterMessage(ApplyStateTransitionRequest)
+_sym_db.RegisterMessage(BroadcastStateTransitionRequest)
 
-ApplyStateTransitionResponse = _reflection.GeneratedProtocolMessageType('ApplyStateTransitionResponse', (_message.Message,), dict(
-  DESCRIPTOR = _APPLYSTATETRANSITIONRESPONSE,
+BroadcastStateTransitionResponse = _reflection.GeneratedProtocolMessageType('BroadcastStateTransitionResponse', (_message.Message,), dict(
+  DESCRIPTOR = _BROADCASTSTATETRANSITIONRESPONSE,
   __module__ = 'platform_pb2'
-  # @@protoc_insertion_point(class_scope:org.dash.platform.dapi.v0.ApplyStateTransitionResponse)
+  # @@protoc_insertion_point(class_scope:org.dash.platform.dapi.v0.BroadcastStateTransitionResponse)
   ))
-_sym_db.RegisterMessage(ApplyStateTransitionResponse)
+_sym_db.RegisterMessage(BroadcastStateTransitionResponse)
 
 GetIdentityRequest = _reflection.GeneratedProtocolMessageType('GetIdentityRequest', (_message.Message,), dict(
   DESCRIPTOR = _GETIDENTITYREQUEST,
@@ -546,16 +546,16 @@ _PLATFORM = _descriptor.ServiceDescriptor(
   file=DESCRIPTOR,
   index=0,
   options=None,
-  serialized_start=752,
-  serialized_end=1569,
+  serialized_start=760,
+  serialized_end=1589,
   methods=[
   _descriptor.MethodDescriptor(
-    name='applyStateTransition',
-    full_name='org.dash.platform.dapi.v0.Platform.applyStateTransition',
+    name='broadcastStateTransition',
+    full_name='org.dash.platform.dapi.v0.Platform.broadcastStateTransition',
     index=0,
     containing_service=None,
-    input_type=_APPLYSTATETRANSITIONREQUEST,
-    output_type=_APPLYSTATETRANSITIONRESPONSE,
+    input_type=_BROADCASTSTATETRANSITIONREQUEST,
+    output_type=_BROADCASTSTATETRANSITIONRESPONSE,
     options=None,
   ),
   _descriptor.MethodDescriptor(
@@ -628,10 +628,10 @@ try:
       Args:
         channel: A grpc.Channel.
       """
-      self.applyStateTransition = channel.unary_unary(
-          '/org.dash.platform.dapi.v0.Platform/applyStateTransition',
-          request_serializer=ApplyStateTransitionRequest.SerializeToString,
-          response_deserializer=ApplyStateTransitionResponse.FromString,
+      self.broadcastStateTransition = channel.unary_unary(
+          '/org.dash.platform.dapi.v0.Platform/broadcastStateTransition',
+          request_serializer=BroadcastStateTransitionRequest.SerializeToString,
+          response_deserializer=BroadcastStateTransitionResponse.FromString,
           )
       self.getIdentity = channel.unary_unary(
           '/org.dash.platform.dapi.v0.Platform/getIdentity',
@@ -664,7 +664,7 @@ try:
     # missing associated documentation comment in .proto file
     pass
 
-    def applyStateTransition(self, request, context):
+    def broadcastStateTransition(self, request, context):
       # missing associated documentation comment in .proto file
       pass
       context.set_code(grpc.StatusCode.UNIMPLEMENTED)
@@ -709,10 +709,10 @@ try:
 
   def add_PlatformServicer_to_server(servicer, server):
     rpc_method_handlers = {
-        'applyStateTransition': grpc.unary_unary_rpc_method_handler(
-            servicer.applyStateTransition,
-            request_deserializer=ApplyStateTransitionRequest.FromString,
-            response_serializer=ApplyStateTransitionResponse.SerializeToString,
+        'broadcastStateTransition': grpc.unary_unary_rpc_method_handler(
+            servicer.broadcastStateTransition,
+            request_deserializer=BroadcastStateTransitionRequest.FromString,
+            response_serializer=BroadcastStateTransitionResponse.SerializeToString,
         ),
         'getIdentity': grpc.unary_unary_rpc_method_handler(
             servicer.getIdentity,
@@ -753,7 +753,7 @@ try:
     only to ease transition from grpcio<0.15.0 to grpcio>=0.15.0."""
     # missing associated documentation comment in .proto file
     pass
-    def applyStateTransition(self, request, context):
+    def broadcastStateTransition(self, request, context):
       # missing associated documentation comment in .proto file
       pass
       context.code(beta_interfaces.StatusCode.UNIMPLEMENTED)
@@ -787,11 +787,11 @@ try:
     only to ease transition from grpcio<0.15.0 to grpcio>=0.15.0."""
     # missing associated documentation comment in .proto file
     pass
-    def applyStateTransition(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
+    def broadcastStateTransition(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
       # missing associated documentation comment in .proto file
       pass
       raise NotImplementedError()
-    applyStateTransition.future = None
+    broadcastStateTransition.future = None
     def getIdentity(self, request, timeout, metadata=None, with_call=False, protocol_options=None):
       # missing associated documentation comment in .proto file
       pass
@@ -826,7 +826,7 @@ try:
     file not marked beta) for all further purposes. This function was
     generated only to ease transition from grpcio<0.15.0 to grpcio>=0.15.0"""
     request_deserializers = {
-      ('org.dash.platform.dapi.v0.Platform', 'applyStateTransition'): ApplyStateTransitionRequest.FromString,
+      ('org.dash.platform.dapi.v0.Platform', 'broadcastStateTransition'): BroadcastStateTransitionRequest.FromString,
       ('org.dash.platform.dapi.v0.Platform', 'getDataContract'): GetDataContractRequest.FromString,
       ('org.dash.platform.dapi.v0.Platform', 'getDocuments'): GetDocumentsRequest.FromString,
       ('org.dash.platform.dapi.v0.Platform', 'getIdentity'): GetIdentityRequest.FromString,
@@ -834,7 +834,7 @@ try:
       ('org.dash.platform.dapi.v0.Platform', 'getIdentityIdByFirstPublicKey'): GetIdentityIdByFirstPublicKeyRequest.FromString,
     }
     response_serializers = {
-      ('org.dash.platform.dapi.v0.Platform', 'applyStateTransition'): ApplyStateTransitionResponse.SerializeToString,
+      ('org.dash.platform.dapi.v0.Platform', 'broadcastStateTransition'): BroadcastStateTransitionResponse.SerializeToString,
       ('org.dash.platform.dapi.v0.Platform', 'getDataContract'): GetDataContractResponse.SerializeToString,
       ('org.dash.platform.dapi.v0.Platform', 'getDocuments'): GetDocumentsResponse.SerializeToString,
       ('org.dash.platform.dapi.v0.Platform', 'getIdentity'): GetIdentityResponse.SerializeToString,
@@ -842,7 +842,7 @@ try:
       ('org.dash.platform.dapi.v0.Platform', 'getIdentityIdByFirstPublicKey'): GetIdentityIdByFirstPublicKeyResponse.SerializeToString,
     }
     method_implementations = {
-      ('org.dash.platform.dapi.v0.Platform', 'applyStateTransition'): face_utilities.unary_unary_inline(servicer.applyStateTransition),
+      ('org.dash.platform.dapi.v0.Platform', 'broadcastStateTransition'): face_utilities.unary_unary_inline(servicer.broadcastStateTransition),
       ('org.dash.platform.dapi.v0.Platform', 'getDataContract'): face_utilities.unary_unary_inline(servicer.getDataContract),
       ('org.dash.platform.dapi.v0.Platform', 'getDocuments'): face_utilities.unary_unary_inline(servicer.getDocuments),
       ('org.dash.platform.dapi.v0.Platform', 'getIdentity'): face_utilities.unary_unary_inline(servicer.getIdentity),
@@ -860,7 +860,7 @@ try:
     file not marked beta) for all further purposes. This function was
     generated only to ease transition from grpcio<0.15.0 to grpcio>=0.15.0"""
     request_serializers = {
-      ('org.dash.platform.dapi.v0.Platform', 'applyStateTransition'): ApplyStateTransitionRequest.SerializeToString,
+      ('org.dash.platform.dapi.v0.Platform', 'broadcastStateTransition'): BroadcastStateTransitionRequest.SerializeToString,
       ('org.dash.platform.dapi.v0.Platform', 'getDataContract'): GetDataContractRequest.SerializeToString,
       ('org.dash.platform.dapi.v0.Platform', 'getDocuments'): GetDocumentsRequest.SerializeToString,
       ('org.dash.platform.dapi.v0.Platform', 'getIdentity'): GetIdentityRequest.SerializeToString,
@@ -868,7 +868,7 @@ try:
       ('org.dash.platform.dapi.v0.Platform', 'getIdentityIdByFirstPublicKey'): GetIdentityIdByFirstPublicKeyRequest.SerializeToString,
     }
     response_deserializers = {
-      ('org.dash.platform.dapi.v0.Platform', 'applyStateTransition'): ApplyStateTransitionResponse.FromString,
+      ('org.dash.platform.dapi.v0.Platform', 'broadcastStateTransition'): BroadcastStateTransitionResponse.FromString,
       ('org.dash.platform.dapi.v0.Platform', 'getDataContract'): GetDataContractResponse.FromString,
       ('org.dash.platform.dapi.v0.Platform', 'getDocuments'): GetDocumentsResponse.FromString,
       ('org.dash.platform.dapi.v0.Platform', 'getIdentity'): GetIdentityResponse.FromString,
@@ -876,7 +876,7 @@ try:
       ('org.dash.platform.dapi.v0.Platform', 'getIdentityIdByFirstPublicKey'): GetIdentityIdByFirstPublicKeyResponse.FromString,
     }
     cardinalities = {
-      'applyStateTransition': cardinality.Cardinality.UNARY_UNARY,
+      'broadcastStateTransition': cardinality.Cardinality.UNARY_UNARY,
       'getDataContract': cardinality.Cardinality.UNARY_UNARY,
       'getDocuments': cardinality.Cardinality.UNARY_UNARY,
       'getIdentity': cardinality.Cardinality.UNARY_UNARY,

--- a/clients/python/platform_pb2_grpc.py
+++ b/clients/python/platform_pb2_grpc.py
@@ -14,10 +14,10 @@ class PlatformStub(object):
     Args:
       channel: A grpc.Channel.
     """
-    self.applyStateTransition = channel.unary_unary(
-        '/org.dash.platform.dapi.v0.Platform/applyStateTransition',
-        request_serializer=platform__pb2.ApplyStateTransitionRequest.SerializeToString,
-        response_deserializer=platform__pb2.ApplyStateTransitionResponse.FromString,
+    self.broadcastStateTransition = channel.unary_unary(
+        '/org.dash.platform.dapi.v0.Platform/broadcastStateTransition',
+        request_serializer=platform__pb2.BroadcastStateTransitionRequest.SerializeToString,
+        response_deserializer=platform__pb2.BroadcastStateTransitionResponse.FromString,
         )
     self.getIdentity = channel.unary_unary(
         '/org.dash.platform.dapi.v0.Platform/getIdentity',
@@ -50,7 +50,7 @@ class PlatformServicer(object):
   # missing associated documentation comment in .proto file
   pass
 
-  def applyStateTransition(self, request, context):
+  def broadcastStateTransition(self, request, context):
     # missing associated documentation comment in .proto file
     pass
     context.set_code(grpc.StatusCode.UNIMPLEMENTED)
@@ -95,10 +95,10 @@ class PlatformServicer(object):
 
 def add_PlatformServicer_to_server(servicer, server):
   rpc_method_handlers = {
-      'applyStateTransition': grpc.unary_unary_rpc_method_handler(
-          servicer.applyStateTransition,
-          request_deserializer=platform__pb2.ApplyStateTransitionRequest.FromString,
-          response_serializer=platform__pb2.ApplyStateTransitionResponse.SerializeToString,
+      'broadcastStateTransition': grpc.unary_unary_rpc_method_handler(
+          servicer.broadcastStateTransition,
+          request_deserializer=platform__pb2.BroadcastStateTransitionRequest.FromString,
+          response_serializer=platform__pb2.BroadcastStateTransitionResponse.SerializeToString,
       ),
       'getIdentity': grpc.unary_unary_rpc_method_handler(
           servicer.getIdentity,

--- a/protos/core.proto
+++ b/protos/core.proto
@@ -5,7 +5,7 @@ package org.dash.platform.dapi.v0;
 service Core {
   rpc getStatus (GetStatusRequest) returns (GetStatusResponse);
   rpc getBlock (GetBlockRequest) returns (GetBlockResponse);
-  rpc sendTransaction (SendTransactionRequest) returns (SendTransactionResponse);
+  rpc broadcastTransaction (BroadcastTransactionRequest) returns (BroadcastTransactionResponse);
   rpc getTransaction (GetTransactionRequest) returns (GetTransactionResponse);
   rpc getEstimatedTransactionFee (GetEstimatedTransactionFeeRequest) returns (GetEstimatedTransactionFeeResponse);
   rpc subscribeToBlockHeadersWithChainLocks (BlockHeadersWithChainLocksRequest) returns (stream BlockHeadersWithChainLocksResponse);
@@ -40,13 +40,13 @@ message GetBlockResponse {
   bytes block = 1;
 }
 
-message SendTransactionRequest {
+message BroadcastTransactionRequest {
   bytes transaction = 1;
   bool allow_high_fees = 2;
   bool bypass_limits = 3;
 }
 
-message SendTransactionResponse {
+message BroadcastTransactionResponse {
   string transaction_id = 1;
 }
 

--- a/protos/platform.proto
+++ b/protos/platform.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 package org.dash.platform.dapi.v0;
 
 service Platform {
-  rpc applyStateTransition (ApplyStateTransitionRequest) returns (ApplyStateTransitionResponse);
+  rpc broadcastStateTransition (BroadcastStateTransitionRequest) returns (BroadcastStateTransitionResponse);
   rpc getIdentity (GetIdentityRequest) returns (GetIdentityResponse);
   rpc getDataContract (GetDataContractRequest) returns (GetDataContractResponse);
   rpc getDocuments (GetDocumentsRequest) returns (GetDocumentsResponse);
@@ -11,11 +11,11 @@ service Platform {
   rpc getIdentityIdByFirstPublicKey (GetIdentityIdByFirstPublicKeyRequest) returns (GetIdentityIdByFirstPublicKeyResponse);
 }
 
-message ApplyStateTransitionRequest {
+message BroadcastStateTransitionRequest {
   bytes state_transition = 1;
 }
 
-message ApplyStateTransitionResponse {
+message BroadcastStateTransitionResponse {
 
 }
 

--- a/test/unit/clients/nodejs/CorePromiseClient.spec.js
+++ b/test/unit/clients/nodejs/CorePromiseClient.spec.js
@@ -13,7 +13,7 @@ describe('CorePromiseClient', () => {
     corePromiseClient.client = {
       getStatus: this.sinon.stub().resolves(response),
       getBlock: this.sinon.stub().resolves(response),
-      sendTransaction: this.sinon.stub().resolves(response),
+      broadcastTransaction: this.sinon.stub().resolves(response),
       getTransaction: this.sinon.stub().resolves(response),
       getEstimatedTransactionFee: this.sinon.stub().resolves(response),
     };
@@ -57,17 +57,17 @@ describe('CorePromiseClient', () => {
     });
   });
 
-  describe('#sendTransaction', () => {
-    it('should send transaction', async () => {
-      const result = await corePromiseClient.sendTransaction(request);
+  describe('#broadcastTransaction', () => {
+    it('should broadcast transaction', async () => {
+      const result = await corePromiseClient.broadcastTransaction(request);
 
       expect(result).to.equal(response);
-      expect(corePromiseClient.client.sendTransaction).to.be.calledOnceWith(request);
+      expect(corePromiseClient.client.broadcastTransaction).to.be.calledOnceWith(request);
     });
 
     it('should throw an error when metadata is not an object', async () => {
       try {
-        corePromiseClient.sendTransaction({}, 'metadata');
+        corePromiseClient.broadcastTransaction({}, 'metadata');
 
         expect.fail('Error was not thrown');
       } catch (e) {

--- a/test/unit/clients/nodejs/PlatformPromiseClient.spec.js
+++ b/test/unit/clients/nodejs/PlatformPromiseClient.spec.js
@@ -11,24 +11,24 @@ describe('PlatformPromiseClient', () => {
 
     platformPromiseClient = new PlatformPromiseClient('https://localhost/');
     platformPromiseClient.client = {
-      applyStateTransition: this.sinon.stub().resolves(response),
+      broadcastStateTransition: this.sinon.stub().resolves(response),
       getIdentity: this.sinon.stub().resolves(response),
       getDataContract: this.sinon.stub().resolves(response),
       getDocuments: this.sinon.stub().resolves(response),
     };
   });
 
-  describe('#applyStateTransition', () => {
-    it('should apply state transition', async () => {
-      const result = await platformPromiseClient.applyStateTransition(request);
+  describe('#broadcastStateTransition', () => {
+    it('should broadcast state transition', async () => {
+      const result = await platformPromiseClient.broadcastStateTransition(request);
 
       expect(result).to.equal(response);
-      expect(platformPromiseClient.client.applyStateTransition).to.be.calledOnceWith(request);
+      expect(platformPromiseClient.client.broadcastStateTransition).to.be.calledOnceWith(request);
     });
 
     it('should throw an error when metadata is not an object', async () => {
       try {
-        platformPromiseClient.applyStateTransition({}, 'metadata');
+        platformPromiseClient.broadcastStateTransition({}, 'metadata');
 
         expect.fail('Error was not thrown');
       } catch (e) {

--- a/test/unit/getCoreDefinition.spec.js
+++ b/test/unit/getCoreDefinition.spec.js
@@ -7,8 +7,8 @@ describe('getCoreDefinition', () => {
     expect(coreDefinition).to.be.an('function');
     expect(coreDefinition).to.have.property('service');
 
-    expect(coreDefinition.service).to.have.property('sendTransaction');
-    expect(coreDefinition.service.sendTransaction.path).to.equal('/org.dash.platform.dapi.v0.Core/sendTransaction');
+    expect(coreDefinition.service).to.have.property('broadcastTransaction');
+    expect(coreDefinition.service.broadcastTransaction.path).to.equal('/org.dash.platform.dapi.v0.Core/broadcastTransaction');
 
     expect(coreDefinition.service).to.have.property('getTransaction');
     expect(coreDefinition.service.getTransaction.path).to.equal('/org.dash.platform.dapi.v0.Core/getTransaction');

--- a/test/unit/getPlatformDefinition.spec.js
+++ b/test/unit/getPlatformDefinition.spec.js
@@ -7,8 +7,8 @@ describe('getPlatformDefinition', () => {
     expect(platformDefinition).to.be.an('function');
     expect(platformDefinition).to.have.property('service');
 
-    expect(platformDefinition.service).to.have.property('applyStateTransition');
-    expect(platformDefinition.service.applyStateTransition.path).to.equal('/org.dash.platform.dapi.v0.Platform/applyStateTransition');
+    expect(platformDefinition.service).to.have.property('broadcastStateTransition');
+    expect(platformDefinition.service.broadcastStateTransition.path).to.equal('/org.dash.platform.dapi.v0.Platform/broadcastStateTransition');
 
     expect(platformDefinition.service).to.have.property('getIdentity');
     expect(platformDefinition.service.getIdentity.path).to.equal('/org.dash.platform.dapi.v0.Platform/getIdentity');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In order to more accurately name DAPI and DAPI gRPC endpoints we need to rename sendTransaction and applyStateTransition methods.

## What was done?
<!--- Describe your changes in detail -->
sendTransaction renamed to broadcastTransaction
applyStateTransition renamed to broadcastStateTransition

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
sendTransaction renamed to broadcastTransaction
applyStateTransition renamed to broadcastStateTransition

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
