### PR TITLE
feat: restructure core status response

### DIFF
--- a/clients/core/v0/objective-c/Core.pbobjc.h
+++ b/clients/core/v0/objective-c/Core.pbobjc.h
@@ -31,9 +31,9 @@ CF_EXTERN_C_BEGIN
 @class BloomFilter;
 @class ChainLockSignatureMessages;
 @class GetStatusResponse_Chain;
+@class GetStatusResponse_Fee;
 @class GetStatusResponse_Masternode;
 @class GetStatusResponse_Network;
-@class GetStatusResponse_Network_Fee;
 @class GetStatusResponse_Time;
 @class GetStatusResponse_Version;
 @class InstantSendLockMessages;
@@ -269,6 +269,21 @@ int32_t GetStatusResponse_Masternode_Status_RawValue(GetStatusResponse_Masternod
  **/
 void SetGetStatusResponse_Masternode_Status_RawValue(GetStatusResponse_Masternode *message, int32_t value);
 
+#pragma mark - GetStatusResponse_Fee
+
+typedef GPB_ENUM(GetStatusResponse_Fee_FieldNumber) {
+  GetStatusResponse_Fee_FieldNumber_Relay = 1,
+  GetStatusResponse_Fee_FieldNumber_Incremental = 2,
+};
+
+@interface GetStatusResponse_Fee : GPBMessage
+
+@property(nonatomic, readwrite) double relay;
+
+@property(nonatomic, readwrite) double incremental;
+
+@end
+
 #pragma mark - GetStatusResponse_Network
 
 typedef GPB_ENUM(GetStatusResponse_Network_FieldNumber) {
@@ -280,24 +295,9 @@ typedef GPB_ENUM(GetStatusResponse_Network_FieldNumber) {
 
 @property(nonatomic, readwrite) uint32_t peersCount;
 
-@property(nonatomic, readwrite, strong, null_resettable) GetStatusResponse_Network_Fee *fee;
+@property(nonatomic, readwrite, strong, null_resettable) GetStatusResponse_Fee *fee;
 /** Test to see if @c fee has been set. */
 @property(nonatomic, readwrite) BOOL hasFee;
-
-@end
-
-#pragma mark - GetStatusResponse_Network_Fee
-
-typedef GPB_ENUM(GetStatusResponse_Network_Fee_FieldNumber) {
-  GetStatusResponse_Network_Fee_FieldNumber_Relay = 1,
-  GetStatusResponse_Network_Fee_FieldNumber_Incremental = 2,
-};
-
-@interface GetStatusResponse_Network_Fee : GPBMessage
-
-@property(nonatomic, readwrite) double relay;
-
-@property(nonatomic, readwrite) double incremental;
 
 @end
 

--- a/clients/core/v0/objective-c/Core.pbobjc.h
+++ b/clients/core/v0/objective-c/Core.pbobjc.h
@@ -30,10 +30,61 @@ CF_EXTERN_C_BEGIN
 @class BlockHeaders;
 @class BloomFilter;
 @class ChainLockSignatureMessages;
+@class GetStatusResponse_Chain;
+@class GetStatusResponse_Network;
+@class GetStatusResponse_Network_Fee;
+@class GetStatusResponse_Time;
+@class GetStatusResponse_Version;
 @class InstantSendLockMessages;
 @class RawTransactions;
 
 NS_ASSUME_NONNULL_BEGIN
+
+#pragma mark - Enum GetStatusResponse_Status
+
+typedef GPB_ENUM(GetStatusResponse_Status) {
+  /**
+   * Value used if any message's field encounters a value that is not defined
+   * by this enum. The message will also have C functions to get/set the rawValue
+   * of the field.
+   **/
+  GetStatusResponse_Status_GPBUnrecognizedEnumeratorValue = kGPBUnrecognizedEnumeratorValue,
+  GetStatusResponse_Status_Unknown = 0,
+  GetStatusResponse_Status_NotStarted = 1,
+  GetStatusResponse_Status_Syncing = 2,
+  GetStatusResponse_Status_Ready = 3,
+};
+
+GPBEnumDescriptor *GetStatusResponse_Status_EnumDescriptor(void);
+
+/**
+ * Checks to see if the given value is defined by the enum or was not known at
+ * the time this source was generated.
+ **/
+BOOL GetStatusResponse_Status_IsValidValue(int32_t value);
+
+#pragma mark - Enum GetStatusResponse_Masternode_SyncStatus
+
+typedef GPB_ENUM(GetStatusResponse_Masternode_SyncStatus) {
+  /**
+   * Value used if any message's field encounters a value that is not defined
+   * by this enum. The message will also have C functions to get/set the rawValue
+   * of the field.
+   **/
+  GetStatusResponse_Masternode_SyncStatus_GPBUnrecognizedEnumeratorValue = kGPBUnrecognizedEnumeratorValue,
+  GetStatusResponse_Masternode_SyncStatus_Unknown = 0,
+  GetStatusResponse_Masternode_SyncStatus_MasternodeSyncBlockchain = 1,
+  GetStatusResponse_Masternode_SyncStatus_MasternodeSyncGovernance = 4,
+  GetStatusResponse_Masternode_SyncStatus_MasternodeSyncFinished = 999,
+};
+
+GPBEnumDescriptor *GetStatusResponse_Masternode_SyncStatus_EnumDescriptor(void);
+
+/**
+ * Checks to see if the given value is defined by the enum or was not known at
+ * the time this source was generated.
+ **/
+BOOL GetStatusResponse_Masternode_SyncStatus_IsValidValue(int32_t value);
 
 #pragma mark - CoreRoot
 
@@ -59,42 +110,185 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - GetStatusResponse
 
 typedef GPB_ENUM(GetStatusResponse_FieldNumber) {
-  GetStatusResponse_FieldNumber_CoreVersion = 1,
-  GetStatusResponse_FieldNumber_ProtocolVersion = 2,
-  GetStatusResponse_FieldNumber_Blocks = 3,
-  GetStatusResponse_FieldNumber_TimeOffset = 4,
-  GetStatusResponse_FieldNumber_Connections = 5,
-  GetStatusResponse_FieldNumber_Proxy = 6,
-  GetStatusResponse_FieldNumber_Difficulty = 7,
-  GetStatusResponse_FieldNumber_Testnet = 8,
-  GetStatusResponse_FieldNumber_RelayFee = 9,
-  GetStatusResponse_FieldNumber_Errors = 10,
-  GetStatusResponse_FieldNumber_Network = 11,
+  GetStatusResponse_FieldNumber_Version = 1,
+  GetStatusResponse_FieldNumber_Time = 2,
+  GetStatusResponse_FieldNumber_Status = 3,
+  GetStatusResponse_FieldNumber_SyncProgress = 4,
+  GetStatusResponse_FieldNumber_Chain = 5,
+  GetStatusResponse_FieldNumber_Network = 6,
 };
 
 @interface GetStatusResponse : GPBMessage
 
-@property(nonatomic, readwrite) uint32_t coreVersion;
+@property(nonatomic, readwrite, strong, null_resettable) GetStatusResponse_Version *version;
+/** Test to see if @c version has been set. */
+@property(nonatomic, readwrite) BOOL hasVersion;
 
-@property(nonatomic, readwrite) uint32_t protocolVersion;
+@property(nonatomic, readwrite, strong, null_resettable) GetStatusResponse_Time *time;
+/** Test to see if @c time has been set. */
+@property(nonatomic, readwrite) BOOL hasTime;
 
-@property(nonatomic, readwrite) uint32_t blocks;
+@property(nonatomic, readwrite) GetStatusResponse_Status status;
 
-@property(nonatomic, readwrite) uint32_t timeOffset;
+@property(nonatomic, readwrite) double syncProgress;
 
-@property(nonatomic, readwrite) uint32_t connections;
+@property(nonatomic, readwrite, strong, null_resettable) GetStatusResponse_Chain *chain;
+/** Test to see if @c chain has been set. */
+@property(nonatomic, readwrite) BOOL hasChain;
 
-@property(nonatomic, readwrite, copy, null_resettable) NSString *proxy;
+@property(nonatomic, readwrite, strong, null_resettable) GetStatusResponse_Network *network;
+/** Test to see if @c network has been set. */
+@property(nonatomic, readwrite) BOOL hasNetwork;
+
+@end
+
+/**
+ * Fetches the raw value of a @c GetStatusResponse's @c status property, even
+ * if the value was not defined by the enum at the time the code was generated.
+ **/
+int32_t GetStatusResponse_Status_RawValue(GetStatusResponse *message);
+/**
+ * Sets the raw value of an @c GetStatusResponse's @c status property, allowing
+ * it to be set to a value that was not defined by the enum at the time the code
+ * was generated.
+ **/
+void SetGetStatusResponse_Status_RawValue(GetStatusResponse *message, int32_t value);
+
+#pragma mark - GetStatusResponse_Version
+
+typedef GPB_ENUM(GetStatusResponse_Version_FieldNumber) {
+  GetStatusResponse_Version_FieldNumber_Protocol = 1,
+  GetStatusResponse_Version_FieldNumber_Software = 2,
+  GetStatusResponse_Version_FieldNumber_Agent = 3,
+};
+
+@interface GetStatusResponse_Version : GPBMessage
+
+@property(nonatomic, readwrite) uint32_t protocol;
+
+@property(nonatomic, readwrite) uint32_t software;
+
+@property(nonatomic, readwrite, copy, null_resettable) NSString *agent;
+
+@end
+
+#pragma mark - GetStatusResponse_Time
+
+typedef GPB_ENUM(GetStatusResponse_Time_FieldNumber) {
+  GetStatusResponse_Time_FieldNumber_Now = 1,
+  GetStatusResponse_Time_FieldNumber_Offset = 2,
+  GetStatusResponse_Time_FieldNumber_Median = 3,
+};
+
+@interface GetStatusResponse_Time : GPBMessage
+
+@property(nonatomic, readwrite) uint32_t now;
+
+@property(nonatomic, readwrite) int32_t offset;
+
+@property(nonatomic, readwrite) uint32_t median;
+
+@end
+
+#pragma mark - GetStatusResponse_Chain
+
+typedef GPB_ENUM(GetStatusResponse_Chain_FieldNumber) {
+  GetStatusResponse_Chain_FieldNumber_Name = 1,
+  GetStatusResponse_Chain_FieldNumber_HeadersCount = 2,
+  GetStatusResponse_Chain_FieldNumber_BlocksCount = 3,
+  GetStatusResponse_Chain_FieldNumber_BestBlockHash = 4,
+  GetStatusResponse_Chain_FieldNumber_Difficulty = 5,
+  GetStatusResponse_Chain_FieldNumber_ChainWork = 6,
+  GetStatusResponse_Chain_FieldNumber_IsSynced = 7,
+  GetStatusResponse_Chain_FieldNumber_SyncProgress = 8,
+};
+
+@interface GetStatusResponse_Chain : GPBMessage
+
+@property(nonatomic, readwrite, copy, null_resettable) NSString *name;
+
+@property(nonatomic, readwrite) uint32_t headersCount;
+
+@property(nonatomic, readwrite) uint32_t blocksCount;
+
+@property(nonatomic, readwrite, copy, null_resettable) NSData *bestBlockHash;
 
 @property(nonatomic, readwrite) double difficulty;
 
-@property(nonatomic, readwrite) BOOL testnet;
+@property(nonatomic, readwrite, copy, null_resettable) NSData *chainWork;
 
-@property(nonatomic, readwrite) double relayFee;
+@property(nonatomic, readwrite) BOOL isSynced;
 
-@property(nonatomic, readwrite, copy, null_resettable) NSString *errors;
+@property(nonatomic, readwrite) double syncProgress;
 
-@property(nonatomic, readwrite, copy, null_resettable) NSString *network;
+@end
+
+#pragma mark - GetStatusResponse_Masternode
+
+typedef GPB_ENUM(GetStatusResponse_Masternode_FieldNumber) {
+  GetStatusResponse_Masternode_FieldNumber_Status = 1,
+  GetStatusResponse_Masternode_FieldNumber_ProTxHash = 2,
+  GetStatusResponse_Masternode_FieldNumber_PosePenalty = 3,
+  GetStatusResponse_Masternode_FieldNumber_IsSynced = 4,
+  GetStatusResponse_Masternode_FieldNumber_SyncStatus = 5,
+};
+
+@interface GetStatusResponse_Masternode : GPBMessage
+
+/** TODO: Make it enum? */
+@property(nonatomic, readwrite, copy, null_resettable) NSString *status;
+
+@property(nonatomic, readwrite, copy, null_resettable) NSData *proTxHash;
+
+@property(nonatomic, readwrite) uint32_t posePenalty;
+
+@property(nonatomic, readwrite) BOOL isSynced;
+
+@property(nonatomic, readwrite) GetStatusResponse_Masternode_SyncStatus syncStatus;
+
+@end
+
+/**
+ * Fetches the raw value of a @c GetStatusResponse_Masternode's @c syncStatus property, even
+ * if the value was not defined by the enum at the time the code was generated.
+ **/
+int32_t GetStatusResponse_Masternode_SyncStatus_RawValue(GetStatusResponse_Masternode *message);
+/**
+ * Sets the raw value of an @c GetStatusResponse_Masternode's @c syncStatus property, allowing
+ * it to be set to a value that was not defined by the enum at the time the code
+ * was generated.
+ **/
+void SetGetStatusResponse_Masternode_SyncStatus_RawValue(GetStatusResponse_Masternode *message, int32_t value);
+
+#pragma mark - GetStatusResponse_Network
+
+typedef GPB_ENUM(GetStatusResponse_Network_FieldNumber) {
+  GetStatusResponse_Network_FieldNumber_PeersCount = 1,
+  GetStatusResponse_Network_FieldNumber_Fee = 2,
+};
+
+@interface GetStatusResponse_Network : GPBMessage
+
+@property(nonatomic, readwrite) uint32_t peersCount;
+
+@property(nonatomic, readwrite, strong, null_resettable) GetStatusResponse_Network_Fee *fee;
+/** Test to see if @c fee has been set. */
+@property(nonatomic, readwrite) BOOL hasFee;
+
+@end
+
+#pragma mark - GetStatusResponse_Network_Fee
+
+typedef GPB_ENUM(GetStatusResponse_Network_Fee_FieldNumber) {
+  GetStatusResponse_Network_Fee_FieldNumber_Relay = 1,
+  GetStatusResponse_Network_Fee_FieldNumber_Incremental = 2,
+};
+
+@interface GetStatusResponse_Network_Fee : GPBMessage
+
+@property(nonatomic, readwrite) double relay;
+
+@property(nonatomic, readwrite) double incremental;
 
 @end
 

--- a/clients/core/v0/objective-c/Core.pbobjc.h
+++ b/clients/core/v0/objective-c/Core.pbobjc.h
@@ -31,9 +31,9 @@ CF_EXTERN_C_BEGIN
 @class BloomFilter;
 @class ChainLockSignatureMessages;
 @class GetStatusResponse_Chain;
-@class GetStatusResponse_Fee;
 @class GetStatusResponse_Masternode;
 @class GetStatusResponse_Network;
+@class GetStatusResponse_NetworkFee;
 @class GetStatusResponse_Time;
 @class GetStatusResponse_Version;
 @class InstantSendLockMessages;
@@ -269,14 +269,14 @@ int32_t GetStatusResponse_Masternode_Status_RawValue(GetStatusResponse_Masternod
  **/
 void SetGetStatusResponse_Masternode_Status_RawValue(GetStatusResponse_Masternode *message, int32_t value);
 
-#pragma mark - GetStatusResponse_Fee
+#pragma mark - GetStatusResponse_NetworkFee
 
-typedef GPB_ENUM(GetStatusResponse_Fee_FieldNumber) {
-  GetStatusResponse_Fee_FieldNumber_Relay = 1,
-  GetStatusResponse_Fee_FieldNumber_Incremental = 2,
+typedef GPB_ENUM(GetStatusResponse_NetworkFee_FieldNumber) {
+  GetStatusResponse_NetworkFee_FieldNumber_Relay = 1,
+  GetStatusResponse_NetworkFee_FieldNumber_Incremental = 2,
 };
 
-@interface GetStatusResponse_Fee : GPBMessage
+@interface GetStatusResponse_NetworkFee : GPBMessage
 
 @property(nonatomic, readwrite) double relay;
 
@@ -295,7 +295,7 @@ typedef GPB_ENUM(GetStatusResponse_Network_FieldNumber) {
 
 @property(nonatomic, readwrite) uint32_t peersCount;
 
-@property(nonatomic, readwrite, strong, null_resettable) GetStatusResponse_Fee *fee;
+@property(nonatomic, readwrite, strong, null_resettable) GetStatusResponse_NetworkFee *fee;
 /** Test to see if @c fee has been set. */
 @property(nonatomic, readwrite) BOOL hasFee;
 

--- a/clients/core/v0/objective-c/Core.pbobjc.h
+++ b/clients/core/v0/objective-c/Core.pbobjc.h
@@ -64,32 +64,32 @@ GPBEnumDescriptor *GetStatusResponse_Status_EnumDescriptor(void);
  **/
 BOOL GetStatusResponse_Status_IsValidValue(int32_t value);
 
-#pragma mark - Enum GetStatusResponse_Masternode_State
+#pragma mark - Enum GetStatusResponse_Masternode_Status
 
-typedef GPB_ENUM(GetStatusResponse_Masternode_State) {
+typedef GPB_ENUM(GetStatusResponse_Masternode_Status) {
   /**
    * Value used if any message's field encounters a value that is not defined
    * by this enum. The message will also have C functions to get/set the rawValue
    * of the field.
    **/
-  GetStatusResponse_Masternode_State_GPBUnrecognizedEnumeratorValue = kGPBUnrecognizedEnumeratorValue,
-  GetStatusResponse_Masternode_State_Unknown = 0,
-  GetStatusResponse_Masternode_State_WaitingForProtx = 1,
-  GetStatusResponse_Masternode_State_PoseBanned = 2,
-  GetStatusResponse_Masternode_State_Removed = 3,
-  GetStatusResponse_Masternode_State_OperatorKeyChanged = 4,
-  GetStatusResponse_Masternode_State_ProtxIpChanged = 5,
-  GetStatusResponse_Masternode_State_Ready = 6,
-  GetStatusResponse_Masternode_State_Error = 7,
+  GetStatusResponse_Masternode_Status_GPBUnrecognizedEnumeratorValue = kGPBUnrecognizedEnumeratorValue,
+  GetStatusResponse_Masternode_Status_Unknown = 0,
+  GetStatusResponse_Masternode_Status_WaitingForProtx = 1,
+  GetStatusResponse_Masternode_Status_PoseBanned = 2,
+  GetStatusResponse_Masternode_Status_Removed = 3,
+  GetStatusResponse_Masternode_Status_OperatorKeyChanged = 4,
+  GetStatusResponse_Masternode_Status_ProtxIpChanged = 5,
+  GetStatusResponse_Masternode_Status_Ready = 6,
+  GetStatusResponse_Masternode_Status_Error = 7,
 };
 
-GPBEnumDescriptor *GetStatusResponse_Masternode_State_EnumDescriptor(void);
+GPBEnumDescriptor *GetStatusResponse_Masternode_Status_EnumDescriptor(void);
 
 /**
  * Checks to see if the given value is defined by the enum or was not known at
  * the time this source was generated.
  **/
-BOOL GetStatusResponse_Masternode_State_IsValidValue(int32_t value);
+BOOL GetStatusResponse_Masternode_Status_IsValidValue(int32_t value);
 
 #pragma mark - CoreRoot
 
@@ -236,7 +236,7 @@ typedef GPB_ENUM(GetStatusResponse_Chain_FieldNumber) {
 #pragma mark - GetStatusResponse_Masternode
 
 typedef GPB_ENUM(GetStatusResponse_Masternode_FieldNumber) {
-  GetStatusResponse_Masternode_FieldNumber_State = 1,
+  GetStatusResponse_Masternode_FieldNumber_Status = 1,
   GetStatusResponse_Masternode_FieldNumber_ProTxHash = 2,
   GetStatusResponse_Masternode_FieldNumber_PosePenalty = 3,
   GetStatusResponse_Masternode_FieldNumber_IsSynced = 4,
@@ -245,7 +245,7 @@ typedef GPB_ENUM(GetStatusResponse_Masternode_FieldNumber) {
 
 @interface GetStatusResponse_Masternode : GPBMessage
 
-@property(nonatomic, readwrite) GetStatusResponse_Status state;
+@property(nonatomic, readwrite) GetStatusResponse_Masternode_Status status;
 
 @property(nonatomic, readwrite, copy, null_resettable) NSData *proTxHash;
 
@@ -258,16 +258,16 @@ typedef GPB_ENUM(GetStatusResponse_Masternode_FieldNumber) {
 @end
 
 /**
- * Fetches the raw value of a @c GetStatusResponse_Masternode's @c state property, even
+ * Fetches the raw value of a @c GetStatusResponse_Masternode's @c status property, even
  * if the value was not defined by the enum at the time the code was generated.
  **/
-int32_t GetStatusResponse_Masternode_State_RawValue(GetStatusResponse_Masternode *message);
+int32_t GetStatusResponse_Masternode_Status_RawValue(GetStatusResponse_Masternode *message);
 /**
- * Sets the raw value of an @c GetStatusResponse_Masternode's @c state property, allowing
+ * Sets the raw value of an @c GetStatusResponse_Masternode's @c status property, allowing
  * it to be set to a value that was not defined by the enum at the time the code
  * was generated.
  **/
-void SetGetStatusResponse_Masternode_State_RawValue(GetStatusResponse_Masternode *message, int32_t value);
+void SetGetStatusResponse_Masternode_Status_RawValue(GetStatusResponse_Masternode *message, int32_t value);
 
 #pragma mark - GetStatusResponse_Network
 

--- a/clients/core/v0/objective-c/Core.pbobjc.h
+++ b/clients/core/v0/objective-c/Core.pbobjc.h
@@ -49,10 +49,10 @@ typedef GPB_ENUM(GetStatusResponse_Status) {
    * of the field.
    **/
   GetStatusResponse_Status_GPBUnrecognizedEnumeratorValue = kGPBUnrecognizedEnumeratorValue,
-  GetStatusResponse_Status_Unknown = 0,
-  GetStatusResponse_Status_NotStarted = 1,
-  GetStatusResponse_Status_Syncing = 2,
-  GetStatusResponse_Status_Ready = 3,
+  GetStatusResponse_Status_NotStarted = 0,
+  GetStatusResponse_Status_Syncing = 1,
+  GetStatusResponse_Status_Ready = 2,
+  GetStatusResponse_Status_Error = 3,
 };
 
 GPBEnumDescriptor *GetStatusResponse_Status_EnumDescriptor(void);
@@ -63,28 +63,32 @@ GPBEnumDescriptor *GetStatusResponse_Status_EnumDescriptor(void);
  **/
 BOOL GetStatusResponse_Status_IsValidValue(int32_t value);
 
-#pragma mark - Enum GetStatusResponse_Masternode_SyncStatus
+#pragma mark - Enum GetStatusResponse_Masternode_Status
 
-typedef GPB_ENUM(GetStatusResponse_Masternode_SyncStatus) {
+typedef GPB_ENUM(GetStatusResponse_Masternode_Status) {
   /**
    * Value used if any message's field encounters a value that is not defined
    * by this enum. The message will also have C functions to get/set the rawValue
    * of the field.
    **/
-  GetStatusResponse_Masternode_SyncStatus_GPBUnrecognizedEnumeratorValue = kGPBUnrecognizedEnumeratorValue,
-  GetStatusResponse_Masternode_SyncStatus_Unknown = 0,
-  GetStatusResponse_Masternode_SyncStatus_MasternodeSyncBlockchain = 1,
-  GetStatusResponse_Masternode_SyncStatus_MasternodeSyncGovernance = 4,
-  GetStatusResponse_Masternode_SyncStatus_MasternodeSyncFinished = 999,
+  GetStatusResponse_Masternode_Status_GPBUnrecognizedEnumeratorValue = kGPBUnrecognizedEnumeratorValue,
+  GetStatusResponse_Masternode_Status_Unknown = 0,
+  GetStatusResponse_Masternode_Status_WaitingForProtx = 1,
+  GetStatusResponse_Masternode_Status_PoseBanned = 2,
+  GetStatusResponse_Masternode_Status_Removed = 3,
+  GetStatusResponse_Masternode_Status_OperatorKeyChanged = 4,
+  GetStatusResponse_Masternode_Status_ProtxIpChanged = 5,
+  GetStatusResponse_Masternode_Status_Ready = 6,
+  GetStatusResponse_Masternode_Status_Error = 7,
 };
 
-GPBEnumDescriptor *GetStatusResponse_Masternode_SyncStatus_EnumDescriptor(void);
+GPBEnumDescriptor *GetStatusResponse_Masternode_Status_EnumDescriptor(void);
 
 /**
  * Checks to see if the given value is defined by the enum or was not known at
  * the time this source was generated.
  **/
-BOOL GetStatusResponse_Masternode_SyncStatus_IsValidValue(int32_t value);
+BOOL GetStatusResponse_Masternode_Status_IsValidValue(int32_t value);
 
 #pragma mark - CoreRoot
 
@@ -230,13 +234,12 @@ typedef GPB_ENUM(GetStatusResponse_Masternode_FieldNumber) {
   GetStatusResponse_Masternode_FieldNumber_ProTxHash = 2,
   GetStatusResponse_Masternode_FieldNumber_PosePenalty = 3,
   GetStatusResponse_Masternode_FieldNumber_IsSynced = 4,
-  GetStatusResponse_Masternode_FieldNumber_SyncStatus = 5,
+  GetStatusResponse_Masternode_FieldNumber_SyncProgress = 5,
 };
 
 @interface GetStatusResponse_Masternode : GPBMessage
 
-/** TODO: Make it enum? */
-@property(nonatomic, readwrite, copy, null_resettable) NSString *status;
+@property(nonatomic, readwrite) GetStatusResponse_Masternode_Status status;
 
 @property(nonatomic, readwrite, copy, null_resettable) NSData *proTxHash;
 
@@ -244,21 +247,21 @@ typedef GPB_ENUM(GetStatusResponse_Masternode_FieldNumber) {
 
 @property(nonatomic, readwrite) BOOL isSynced;
 
-@property(nonatomic, readwrite) GetStatusResponse_Masternode_SyncStatus syncStatus;
+@property(nonatomic, readwrite) double syncProgress;
 
 @end
 
 /**
- * Fetches the raw value of a @c GetStatusResponse_Masternode's @c syncStatus property, even
+ * Fetches the raw value of a @c GetStatusResponse_Masternode's @c status property, even
  * if the value was not defined by the enum at the time the code was generated.
  **/
-int32_t GetStatusResponse_Masternode_SyncStatus_RawValue(GetStatusResponse_Masternode *message);
+int32_t GetStatusResponse_Masternode_Status_RawValue(GetStatusResponse_Masternode *message);
 /**
- * Sets the raw value of an @c GetStatusResponse_Masternode's @c syncStatus property, allowing
+ * Sets the raw value of an @c GetStatusResponse_Masternode's @c status property, allowing
  * it to be set to a value that was not defined by the enum at the time the code
  * was generated.
  **/
-void SetGetStatusResponse_Masternode_SyncStatus_RawValue(GetStatusResponse_Masternode *message, int32_t value);
+void SetGetStatusResponse_Masternode_Status_RawValue(GetStatusResponse_Masternode *message, int32_t value);
 
 #pragma mark - GetStatusResponse_Network
 

--- a/clients/core/v0/objective-c/Core.pbobjc.h
+++ b/clients/core/v0/objective-c/Core.pbobjc.h
@@ -31,6 +31,7 @@ CF_EXTERN_C_BEGIN
 @class BloomFilter;
 @class ChainLockSignatureMessages;
 @class GetStatusResponse_Chain;
+@class GetStatusResponse_Masternode;
 @class GetStatusResponse_Network;
 @class GetStatusResponse_Network_Fee;
 @class GetStatusResponse_Time;
@@ -63,32 +64,32 @@ GPBEnumDescriptor *GetStatusResponse_Status_EnumDescriptor(void);
  **/
 BOOL GetStatusResponse_Status_IsValidValue(int32_t value);
 
-#pragma mark - Enum GetStatusResponse_Masternode_Status
+#pragma mark - Enum GetStatusResponse_Masternode_State
 
-typedef GPB_ENUM(GetStatusResponse_Masternode_Status) {
+typedef GPB_ENUM(GetStatusResponse_Masternode_State) {
   /**
    * Value used if any message's field encounters a value that is not defined
    * by this enum. The message will also have C functions to get/set the rawValue
    * of the field.
    **/
-  GetStatusResponse_Masternode_Status_GPBUnrecognizedEnumeratorValue = kGPBUnrecognizedEnumeratorValue,
-  GetStatusResponse_Masternode_Status_Unknown = 0,
-  GetStatusResponse_Masternode_Status_WaitingForProtx = 1,
-  GetStatusResponse_Masternode_Status_PoseBanned = 2,
-  GetStatusResponse_Masternode_Status_Removed = 3,
-  GetStatusResponse_Masternode_Status_OperatorKeyChanged = 4,
-  GetStatusResponse_Masternode_Status_ProtxIpChanged = 5,
-  GetStatusResponse_Masternode_Status_Ready = 6,
-  GetStatusResponse_Masternode_Status_Error = 7,
+  GetStatusResponse_Masternode_State_GPBUnrecognizedEnumeratorValue = kGPBUnrecognizedEnumeratorValue,
+  GetStatusResponse_Masternode_State_Unknown = 0,
+  GetStatusResponse_Masternode_State_WaitingForProtx = 1,
+  GetStatusResponse_Masternode_State_PoseBanned = 2,
+  GetStatusResponse_Masternode_State_Removed = 3,
+  GetStatusResponse_Masternode_State_OperatorKeyChanged = 4,
+  GetStatusResponse_Masternode_State_ProtxIpChanged = 5,
+  GetStatusResponse_Masternode_State_Ready = 6,
+  GetStatusResponse_Masternode_State_Error = 7,
 };
 
-GPBEnumDescriptor *GetStatusResponse_Masternode_Status_EnumDescriptor(void);
+GPBEnumDescriptor *GetStatusResponse_Masternode_State_EnumDescriptor(void);
 
 /**
  * Checks to see if the given value is defined by the enum or was not known at
  * the time this source was generated.
  **/
-BOOL GetStatusResponse_Masternode_Status_IsValidValue(int32_t value);
+BOOL GetStatusResponse_Masternode_State_IsValidValue(int32_t value);
 
 #pragma mark - CoreRoot
 
@@ -119,7 +120,8 @@ typedef GPB_ENUM(GetStatusResponse_FieldNumber) {
   GetStatusResponse_FieldNumber_Status = 3,
   GetStatusResponse_FieldNumber_SyncProgress = 4,
   GetStatusResponse_FieldNumber_Chain = 5,
-  GetStatusResponse_FieldNumber_Network = 6,
+  GetStatusResponse_FieldNumber_Masternode = 6,
+  GetStatusResponse_FieldNumber_Network = 7,
 };
 
 @interface GetStatusResponse : GPBMessage
@@ -139,6 +141,10 @@ typedef GPB_ENUM(GetStatusResponse_FieldNumber) {
 @property(nonatomic, readwrite, strong, null_resettable) GetStatusResponse_Chain *chain;
 /** Test to see if @c chain has been set. */
 @property(nonatomic, readwrite) BOOL hasChain;
+
+@property(nonatomic, readwrite, strong, null_resettable) GetStatusResponse_Masternode *masternode;
+/** Test to see if @c masternode has been set. */
+@property(nonatomic, readwrite) BOOL hasMasternode;
 
 @property(nonatomic, readwrite, strong, null_resettable) GetStatusResponse_Network *network;
 /** Test to see if @c network has been set. */
@@ -230,7 +236,7 @@ typedef GPB_ENUM(GetStatusResponse_Chain_FieldNumber) {
 #pragma mark - GetStatusResponse_Masternode
 
 typedef GPB_ENUM(GetStatusResponse_Masternode_FieldNumber) {
-  GetStatusResponse_Masternode_FieldNumber_Status = 1,
+  GetStatusResponse_Masternode_FieldNumber_State = 1,
   GetStatusResponse_Masternode_FieldNumber_ProTxHash = 2,
   GetStatusResponse_Masternode_FieldNumber_PosePenalty = 3,
   GetStatusResponse_Masternode_FieldNumber_IsSynced = 4,
@@ -239,7 +245,7 @@ typedef GPB_ENUM(GetStatusResponse_Masternode_FieldNumber) {
 
 @interface GetStatusResponse_Masternode : GPBMessage
 
-@property(nonatomic, readwrite) GetStatusResponse_Masternode_Status status;
+@property(nonatomic, readwrite) GetStatusResponse_Status state;
 
 @property(nonatomic, readwrite, copy, null_resettable) NSData *proTxHash;
 
@@ -252,16 +258,16 @@ typedef GPB_ENUM(GetStatusResponse_Masternode_FieldNumber) {
 @end
 
 /**
- * Fetches the raw value of a @c GetStatusResponse_Masternode's @c status property, even
+ * Fetches the raw value of a @c GetStatusResponse_Masternode's @c state property, even
  * if the value was not defined by the enum at the time the code was generated.
  **/
-int32_t GetStatusResponse_Masternode_Status_RawValue(GetStatusResponse_Masternode *message);
+int32_t GetStatusResponse_Masternode_State_RawValue(GetStatusResponse_Masternode *message);
 /**
- * Sets the raw value of an @c GetStatusResponse_Masternode's @c status property, allowing
+ * Sets the raw value of an @c GetStatusResponse_Masternode's @c state property, allowing
  * it to be set to a value that was not defined by the enum at the time the code
  * was generated.
  **/
-void SetGetStatusResponse_Masternode_Status_RawValue(GetStatusResponse_Masternode *message, int32_t value);
+void SetGetStatusResponse_Masternode_State_RawValue(GetStatusResponse_Masternode *message, int32_t value);
 
 #pragma mark - GetStatusResponse_Network
 

--- a/clients/core/v0/objective-c/Core.pbobjc.m
+++ b/clients/core/v0/objective-c/Core.pbobjc.m
@@ -189,12 +189,12 @@ GPBEnumDescriptor *GetStatusResponse_Status_EnumDescriptor(void) {
   static GPBEnumDescriptor *descriptor = NULL;
   if (!descriptor) {
     static const char *valueNames =
-        "Unknown\000NotStarted\000Syncing\000Ready\000";
+        "NotStarted\000Syncing\000Ready\000Error\000";
     static const int32_t values[] = {
-        GetStatusResponse_Status_Unknown,
         GetStatusResponse_Status_NotStarted,
         GetStatusResponse_Status_Syncing,
         GetStatusResponse_Status_Ready,
+        GetStatusResponse_Status_Error,
     };
     GPBEnumDescriptor *worker =
         [GPBEnumDescriptor allocDescriptorForName:GPBNSStringifySymbol(GetStatusResponse_Status)
@@ -211,10 +211,10 @@ GPBEnumDescriptor *GetStatusResponse_Status_EnumDescriptor(void) {
 
 BOOL GetStatusResponse_Status_IsValidValue(int32_t value__) {
   switch (value__) {
-    case GetStatusResponse_Status_Unknown:
     case GetStatusResponse_Status_NotStarted:
     case GetStatusResponse_Status_Syncing:
     case GetStatusResponse_Status_Ready:
+    case GetStatusResponse_Status_Error:
       return YES;
     default:
       return NO;
@@ -481,14 +481,14 @@ typedef struct GetStatusResponse_Chain__storage_ {
 @dynamic proTxHash;
 @dynamic posePenalty;
 @dynamic isSynced;
-@dynamic syncStatus;
+@dynamic syncProgress;
 
 typedef struct GetStatusResponse_Masternode__storage_ {
   uint32_t _has_storage_[1];
+  GetStatusResponse_Masternode_Status status;
   uint32_t posePenalty;
-  GetStatusResponse_Masternode_SyncStatus syncStatus;
-  NSString *status;
   NSData *proTxHash;
+  double syncProgress;
 } GetStatusResponse_Masternode__storage_;
 
 // This method is threadsafe because it is initially called
@@ -499,12 +499,12 @@ typedef struct GetStatusResponse_Masternode__storage_ {
     static GPBMessageFieldDescription fields[] = {
       {
         .name = "status",
-        .dataTypeSpecific.className = NULL,
+        .dataTypeSpecific.enumDescFunc = GetStatusResponse_Masternode_Status_EnumDescriptor,
         .number = GetStatusResponse_Masternode_FieldNumber_Status,
         .hasIndex = 0,
         .offset = (uint32_t)offsetof(GetStatusResponse_Masternode__storage_, status),
-        .flags = GPBFieldOptional,
-        .dataType = GPBDataTypeString,
+        .flags = (GPBFieldFlags)(GPBFieldOptional | GPBFieldHasEnumDescriptor),
+        .dataType = GPBDataTypeEnum,
       },
       {
         .name = "proTxHash",
@@ -534,13 +534,13 @@ typedef struct GetStatusResponse_Masternode__storage_ {
         .dataType = GPBDataTypeBool,
       },
       {
-        .name = "syncStatus",
-        .dataTypeSpecific.enumDescFunc = GetStatusResponse_Masternode_SyncStatus_EnumDescriptor,
-        .number = GetStatusResponse_Masternode_FieldNumber_SyncStatus,
+        .name = "syncProgress",
+        .dataTypeSpecific.className = NULL,
+        .number = GetStatusResponse_Masternode_FieldNumber_SyncProgress,
         .hasIndex = 5,
-        .offset = (uint32_t)offsetof(GetStatusResponse_Masternode__storage_, syncStatus),
-        .flags = (GPBFieldFlags)(GPBFieldOptional | GPBFieldHasEnumDescriptor),
-        .dataType = GPBDataTypeEnum,
+        .offset = (uint32_t)offsetof(GetStatusResponse_Masternode__storage_, syncProgress),
+        .flags = GPBFieldOptional,
+        .dataType = GPBDataTypeDouble,
       },
     };
     GPBDescriptor *localDescriptor =
@@ -565,39 +565,43 @@ typedef struct GetStatusResponse_Masternode__storage_ {
 
 @end
 
-int32_t GetStatusResponse_Masternode_SyncStatus_RawValue(GetStatusResponse_Masternode *message) {
+int32_t GetStatusResponse_Masternode_Status_RawValue(GetStatusResponse_Masternode *message) {
   GPBDescriptor *descriptor = [GetStatusResponse_Masternode descriptor];
-  GPBFieldDescriptor *field = [descriptor fieldWithNumber:GetStatusResponse_Masternode_FieldNumber_SyncStatus];
+  GPBFieldDescriptor *field = [descriptor fieldWithNumber:GetStatusResponse_Masternode_FieldNumber_Status];
   return GPBGetMessageInt32Field(message, field);
 }
 
-void SetGetStatusResponse_Masternode_SyncStatus_RawValue(GetStatusResponse_Masternode *message, int32_t value) {
+void SetGetStatusResponse_Masternode_Status_RawValue(GetStatusResponse_Masternode *message, int32_t value) {
   GPBDescriptor *descriptor = [GetStatusResponse_Masternode descriptor];
-  GPBFieldDescriptor *field = [descriptor fieldWithNumber:GetStatusResponse_Masternode_FieldNumber_SyncStatus];
+  GPBFieldDescriptor *field = [descriptor fieldWithNumber:GetStatusResponse_Masternode_FieldNumber_Status];
   GPBSetInt32IvarWithFieldInternal(message, field, value, descriptor.file.syntax);
 }
 
-#pragma mark - Enum GetStatusResponse_Masternode_SyncStatus
+#pragma mark - Enum GetStatusResponse_Masternode_Status
 
-GPBEnumDescriptor *GetStatusResponse_Masternode_SyncStatus_EnumDescriptor(void) {
+GPBEnumDescriptor *GetStatusResponse_Masternode_Status_EnumDescriptor(void) {
   static GPBEnumDescriptor *descriptor = NULL;
   if (!descriptor) {
     static const char *valueNames =
-        "Unknown\000MasternodeSyncBlockchain\000Mastern"
-        "odeSyncGovernance\000MasternodeSyncFinished"
-        "\000";
+        "Unknown\000WaitingForProtx\000PoseBanned\000Remov"
+        "ed\000OperatorKeyChanged\000ProtxIpChanged\000Rea"
+        "dy\000Error\000";
     static const int32_t values[] = {
-        GetStatusResponse_Masternode_SyncStatus_Unknown,
-        GetStatusResponse_Masternode_SyncStatus_MasternodeSyncBlockchain,
-        GetStatusResponse_Masternode_SyncStatus_MasternodeSyncGovernance,
-        GetStatusResponse_Masternode_SyncStatus_MasternodeSyncFinished,
+        GetStatusResponse_Masternode_Status_Unknown,
+        GetStatusResponse_Masternode_Status_WaitingForProtx,
+        GetStatusResponse_Masternode_Status_PoseBanned,
+        GetStatusResponse_Masternode_Status_Removed,
+        GetStatusResponse_Masternode_Status_OperatorKeyChanged,
+        GetStatusResponse_Masternode_Status_ProtxIpChanged,
+        GetStatusResponse_Masternode_Status_Ready,
+        GetStatusResponse_Masternode_Status_Error,
     };
     GPBEnumDescriptor *worker =
-        [GPBEnumDescriptor allocDescriptorForName:GPBNSStringifySymbol(GetStatusResponse_Masternode_SyncStatus)
+        [GPBEnumDescriptor allocDescriptorForName:GPBNSStringifySymbol(GetStatusResponse_Masternode_Status)
                                        valueNames:valueNames
                                            values:values
                                             count:(uint32_t)(sizeof(values) / sizeof(int32_t))
-                                     enumVerifier:GetStatusResponse_Masternode_SyncStatus_IsValidValue];
+                                     enumVerifier:GetStatusResponse_Masternode_Status_IsValidValue];
     if (!OSAtomicCompareAndSwapPtrBarrier(nil, worker, (void * volatile *)&descriptor)) {
       [worker release];
     }
@@ -605,12 +609,16 @@ GPBEnumDescriptor *GetStatusResponse_Masternode_SyncStatus_EnumDescriptor(void) 
   return descriptor;
 }
 
-BOOL GetStatusResponse_Masternode_SyncStatus_IsValidValue(int32_t value__) {
+BOOL GetStatusResponse_Masternode_Status_IsValidValue(int32_t value__) {
   switch (value__) {
-    case GetStatusResponse_Masternode_SyncStatus_Unknown:
-    case GetStatusResponse_Masternode_SyncStatus_MasternodeSyncBlockchain:
-    case GetStatusResponse_Masternode_SyncStatus_MasternodeSyncGovernance:
-    case GetStatusResponse_Masternode_SyncStatus_MasternodeSyncFinished:
+    case GetStatusResponse_Masternode_Status_Unknown:
+    case GetStatusResponse_Masternode_Status_WaitingForProtx:
+    case GetStatusResponse_Masternode_Status_PoseBanned:
+    case GetStatusResponse_Masternode_Status_Removed:
+    case GetStatusResponse_Masternode_Status_OperatorKeyChanged:
+    case GetStatusResponse_Masternode_Status_ProtxIpChanged:
+    case GetStatusResponse_Masternode_Status_Ready:
+    case GetStatusResponse_Masternode_Status_Error:
       return YES;
     default:
       return NO;

--- a/clients/core/v0/objective-c/Core.pbobjc.m
+++ b/clients/core/v0/objective-c/Core.pbobjc.m
@@ -631,18 +631,18 @@ BOOL GetStatusResponse_Masternode_Status_IsValidValue(int32_t value__) {
   }
 }
 
-#pragma mark - GetStatusResponse_Fee
+#pragma mark - GetStatusResponse_NetworkFee
 
-@implementation GetStatusResponse_Fee
+@implementation GetStatusResponse_NetworkFee
 
 @dynamic relay;
 @dynamic incremental;
 
-typedef struct GetStatusResponse_Fee__storage_ {
+typedef struct GetStatusResponse_NetworkFee__storage_ {
   uint32_t _has_storage_[1];
   double relay;
   double incremental;
-} GetStatusResponse_Fee__storage_;
+} GetStatusResponse_NetworkFee__storage_;
 
 // This method is threadsafe because it is initially called
 // in +initialize for each subclass.
@@ -653,29 +653,29 @@ typedef struct GetStatusResponse_Fee__storage_ {
       {
         .name = "relay",
         .dataTypeSpecific.className = NULL,
-        .number = GetStatusResponse_Fee_FieldNumber_Relay,
+        .number = GetStatusResponse_NetworkFee_FieldNumber_Relay,
         .hasIndex = 0,
-        .offset = (uint32_t)offsetof(GetStatusResponse_Fee__storage_, relay),
+        .offset = (uint32_t)offsetof(GetStatusResponse_NetworkFee__storage_, relay),
         .flags = GPBFieldOptional,
         .dataType = GPBDataTypeDouble,
       },
       {
         .name = "incremental",
         .dataTypeSpecific.className = NULL,
-        .number = GetStatusResponse_Fee_FieldNumber_Incremental,
+        .number = GetStatusResponse_NetworkFee_FieldNumber_Incremental,
         .hasIndex = 1,
-        .offset = (uint32_t)offsetof(GetStatusResponse_Fee__storage_, incremental),
+        .offset = (uint32_t)offsetof(GetStatusResponse_NetworkFee__storage_, incremental),
         .flags = GPBFieldOptional,
         .dataType = GPBDataTypeDouble,
       },
     };
     GPBDescriptor *localDescriptor =
-        [GPBDescriptor allocDescriptorForClass:[GetStatusResponse_Fee class]
+        [GPBDescriptor allocDescriptorForClass:[GetStatusResponse_NetworkFee class]
                                      rootClass:[CoreRoot class]
                                           file:CoreRoot_FileDescriptor()
                                         fields:fields
                                     fieldCount:(uint32_t)(sizeof(fields) / sizeof(GPBMessageFieldDescription))
-                                   storageSize:sizeof(GetStatusResponse_Fee__storage_)
+                                   storageSize:sizeof(GetStatusResponse_NetworkFee__storage_)
                                          flags:GPBDescriptorInitializationFlag_None];
     [localDescriptor setupContainingMessageClassName:GPBStringifySymbol(GetStatusResponse)];
     NSAssert(descriptor == nil, @"Startup recursed!");
@@ -696,7 +696,7 @@ typedef struct GetStatusResponse_Fee__storage_ {
 typedef struct GetStatusResponse_Network__storage_ {
   uint32_t _has_storage_[1];
   uint32_t peersCount;
-  GetStatusResponse_Fee *fee;
+  GetStatusResponse_NetworkFee *fee;
 } GetStatusResponse_Network__storage_;
 
 // This method is threadsafe because it is initially called
@@ -716,7 +716,7 @@ typedef struct GetStatusResponse_Network__storage_ {
       },
       {
         .name = "fee",
-        .dataTypeSpecific.className = GPBStringifySymbol(GetStatusResponse_Fee),
+        .dataTypeSpecific.className = GPBStringifySymbol(GetStatusResponse_NetworkFee),
         .number = GetStatusResponse_Network_FieldNumber_Fee,
         .hasIndex = 1,
         .offset = (uint32_t)offsetof(GetStatusResponse_Network__storage_, fee),

--- a/clients/core/v0/objective-c/Core.pbobjc.m
+++ b/clients/core/v0/objective-c/Core.pbobjc.m
@@ -521,7 +521,7 @@ typedef struct GetStatusResponse_Masternode__storage_ {
         .number = GetStatusResponse_Masternode_FieldNumber_PosePenalty,
         .hasIndex = 2,
         .offset = (uint32_t)offsetof(GetStatusResponse_Masternode__storage_, posePenalty),
-        .flags = (GPBFieldFlags)(GPBFieldOptional | GPBFieldTextFormatNameCustom),
+        .flags = GPBFieldOptional,
         .dataType = GPBDataTypeUInt32,
       },
       {
@@ -551,11 +551,6 @@ typedef struct GetStatusResponse_Masternode__storage_ {
                                     fieldCount:(uint32_t)(sizeof(fields) / sizeof(GPBMessageFieldDescription))
                                    storageSize:sizeof(GetStatusResponse_Masternode__storage_)
                                          flags:GPBDescriptorInitializationFlag_None];
-#if !GPBOBJC_SKIP_MESSAGE_TEXTFORMAT_EXTRAS
-    static const char *extraTextFormatInfo =
-        "\001\003\013\000";
-    [localDescriptor setupExtraTextInfo:extraTextFormatInfo];
-#endif  // !GPBOBJC_SKIP_MESSAGE_TEXTFORMAT_EXTRAS
     [localDescriptor setupContainingMessageClassName:GPBStringifySymbol(GetStatusResponse)];
     NSAssert(descriptor == nil, @"Startup recursed!");
     descriptor = localDescriptor;
@@ -650,7 +645,7 @@ typedef struct GetStatusResponse_Network__storage_ {
         .number = GetStatusResponse_Network_FieldNumber_PeersCount,
         .hasIndex = 0,
         .offset = (uint32_t)offsetof(GetStatusResponse_Network__storage_, peersCount),
-        .flags = (GPBFieldFlags)(GPBFieldOptional | GPBFieldTextFormatNameCustom),
+        .flags = GPBFieldOptional,
         .dataType = GPBDataTypeUInt32,
       },
       {
@@ -671,11 +666,6 @@ typedef struct GetStatusResponse_Network__storage_ {
                                     fieldCount:(uint32_t)(sizeof(fields) / sizeof(GPBMessageFieldDescription))
                                    storageSize:sizeof(GetStatusResponse_Network__storage_)
                                          flags:GPBDescriptorInitializationFlag_None];
-#if !GPBOBJC_SKIP_MESSAGE_TEXTFORMAT_EXTRAS
-    static const char *extraTextFormatInfo =
-        "\001\001\n\000";
-    [localDescriptor setupExtraTextInfo:extraTextFormatInfo];
-#endif  // !GPBOBJC_SKIP_MESSAGE_TEXTFORMAT_EXTRAS
     [localDescriptor setupContainingMessageClassName:GPBStringifySymbol(GetStatusResponse)];
     NSAssert(descriptor == nil, @"Startup recursed!");
     descriptor = localDescriptor;

--- a/clients/core/v0/objective-c/Core.pbobjc.m
+++ b/clients/core/v0/objective-c/Core.pbobjc.m
@@ -631,6 +631,61 @@ BOOL GetStatusResponse_Masternode_Status_IsValidValue(int32_t value__) {
   }
 }
 
+#pragma mark - GetStatusResponse_Fee
+
+@implementation GetStatusResponse_Fee
+
+@dynamic relay;
+@dynamic incremental;
+
+typedef struct GetStatusResponse_Fee__storage_ {
+  uint32_t _has_storage_[1];
+  double relay;
+  double incremental;
+} GetStatusResponse_Fee__storage_;
+
+// This method is threadsafe because it is initially called
+// in +initialize for each subclass.
++ (GPBDescriptor *)descriptor {
+  static GPBDescriptor *descriptor = nil;
+  if (!descriptor) {
+    static GPBMessageFieldDescription fields[] = {
+      {
+        .name = "relay",
+        .dataTypeSpecific.className = NULL,
+        .number = GetStatusResponse_Fee_FieldNumber_Relay,
+        .hasIndex = 0,
+        .offset = (uint32_t)offsetof(GetStatusResponse_Fee__storage_, relay),
+        .flags = GPBFieldOptional,
+        .dataType = GPBDataTypeDouble,
+      },
+      {
+        .name = "incremental",
+        .dataTypeSpecific.className = NULL,
+        .number = GetStatusResponse_Fee_FieldNumber_Incremental,
+        .hasIndex = 1,
+        .offset = (uint32_t)offsetof(GetStatusResponse_Fee__storage_, incremental),
+        .flags = GPBFieldOptional,
+        .dataType = GPBDataTypeDouble,
+      },
+    };
+    GPBDescriptor *localDescriptor =
+        [GPBDescriptor allocDescriptorForClass:[GetStatusResponse_Fee class]
+                                     rootClass:[CoreRoot class]
+                                          file:CoreRoot_FileDescriptor()
+                                        fields:fields
+                                    fieldCount:(uint32_t)(sizeof(fields) / sizeof(GPBMessageFieldDescription))
+                                   storageSize:sizeof(GetStatusResponse_Fee__storage_)
+                                         flags:GPBDescriptorInitializationFlag_None];
+    [localDescriptor setupContainingMessageClassName:GPBStringifySymbol(GetStatusResponse)];
+    NSAssert(descriptor == nil, @"Startup recursed!");
+    descriptor = localDescriptor;
+  }
+  return descriptor;
+}
+
+@end
+
 #pragma mark - GetStatusResponse_Network
 
 @implementation GetStatusResponse_Network
@@ -641,7 +696,7 @@ BOOL GetStatusResponse_Masternode_Status_IsValidValue(int32_t value__) {
 typedef struct GetStatusResponse_Network__storage_ {
   uint32_t _has_storage_[1];
   uint32_t peersCount;
-  GetStatusResponse_Network_Fee *fee;
+  GetStatusResponse_Fee *fee;
 } GetStatusResponse_Network__storage_;
 
 // This method is threadsafe because it is initially called
@@ -661,7 +716,7 @@ typedef struct GetStatusResponse_Network__storage_ {
       },
       {
         .name = "fee",
-        .dataTypeSpecific.className = GPBStringifySymbol(GetStatusResponse_Network_Fee),
+        .dataTypeSpecific.className = GPBStringifySymbol(GetStatusResponse_Fee),
         .number = GetStatusResponse_Network_FieldNumber_Fee,
         .hasIndex = 1,
         .offset = (uint32_t)offsetof(GetStatusResponse_Network__storage_, fee),
@@ -678,61 +733,6 @@ typedef struct GetStatusResponse_Network__storage_ {
                                    storageSize:sizeof(GetStatusResponse_Network__storage_)
                                          flags:GPBDescriptorInitializationFlag_None];
     [localDescriptor setupContainingMessageClassName:GPBStringifySymbol(GetStatusResponse)];
-    NSAssert(descriptor == nil, @"Startup recursed!");
-    descriptor = localDescriptor;
-  }
-  return descriptor;
-}
-
-@end
-
-#pragma mark - GetStatusResponse_Network_Fee
-
-@implementation GetStatusResponse_Network_Fee
-
-@dynamic relay;
-@dynamic incremental;
-
-typedef struct GetStatusResponse_Network_Fee__storage_ {
-  uint32_t _has_storage_[1];
-  double relay;
-  double incremental;
-} GetStatusResponse_Network_Fee__storage_;
-
-// This method is threadsafe because it is initially called
-// in +initialize for each subclass.
-+ (GPBDescriptor *)descriptor {
-  static GPBDescriptor *descriptor = nil;
-  if (!descriptor) {
-    static GPBMessageFieldDescription fields[] = {
-      {
-        .name = "relay",
-        .dataTypeSpecific.className = NULL,
-        .number = GetStatusResponse_Network_Fee_FieldNumber_Relay,
-        .hasIndex = 0,
-        .offset = (uint32_t)offsetof(GetStatusResponse_Network_Fee__storage_, relay),
-        .flags = GPBFieldOptional,
-        .dataType = GPBDataTypeDouble,
-      },
-      {
-        .name = "incremental",
-        .dataTypeSpecific.className = NULL,
-        .number = GetStatusResponse_Network_Fee_FieldNumber_Incremental,
-        .hasIndex = 1,
-        .offset = (uint32_t)offsetof(GetStatusResponse_Network_Fee__storage_, incremental),
-        .flags = GPBFieldOptional,
-        .dataType = GPBDataTypeDouble,
-      },
-    };
-    GPBDescriptor *localDescriptor =
-        [GPBDescriptor allocDescriptorForClass:[GetStatusResponse_Network_Fee class]
-                                     rootClass:[CoreRoot class]
-                                          file:CoreRoot_FileDescriptor()
-                                        fields:fields
-                                    fieldCount:(uint32_t)(sizeof(fields) / sizeof(GPBMessageFieldDescription))
-                                   storageSize:sizeof(GetStatusResponse_Network_Fee__storage_)
-                                         flags:GPBDescriptorInitializationFlag_None];
-    [localDescriptor setupContainingMessageClassName:GPBStringifySymbol(GetStatusResponse_Network)];
     NSAssert(descriptor == nil, @"Startup recursed!");
     descriptor = localDescriptor;
   }

--- a/clients/core/v0/objective-c/Core.pbobjc.m
+++ b/clients/core/v0/objective-c/Core.pbobjc.m
@@ -488,7 +488,7 @@ typedef struct GetStatusResponse_Chain__storage_ {
 
 @implementation GetStatusResponse_Masternode
 
-@dynamic state;
+@dynamic status;
 @dynamic proTxHash;
 @dynamic posePenalty;
 @dynamic isSynced;
@@ -496,7 +496,7 @@ typedef struct GetStatusResponse_Chain__storage_ {
 
 typedef struct GetStatusResponse_Masternode__storage_ {
   uint32_t _has_storage_[1];
-  GetStatusResponse_Status state;
+  GetStatusResponse_Masternode_Status status;
   uint32_t posePenalty;
   NSData *proTxHash;
   double syncProgress;
@@ -509,11 +509,11 @@ typedef struct GetStatusResponse_Masternode__storage_ {
   if (!descriptor) {
     static GPBMessageFieldDescription fields[] = {
       {
-        .name = "state",
-        .dataTypeSpecific.enumDescFunc = GetStatusResponse_Status_EnumDescriptor,
-        .number = GetStatusResponse_Masternode_FieldNumber_State,
+        .name = "status",
+        .dataTypeSpecific.enumDescFunc = GetStatusResponse_Masternode_Status_EnumDescriptor,
+        .number = GetStatusResponse_Masternode_FieldNumber_Status,
         .hasIndex = 0,
-        .offset = (uint32_t)offsetof(GetStatusResponse_Masternode__storage_, state),
+        .offset = (uint32_t)offsetof(GetStatusResponse_Masternode__storage_, status),
         .flags = (GPBFieldFlags)(GPBFieldOptional | GPBFieldHasEnumDescriptor),
         .dataType = GPBDataTypeEnum,
       },
@@ -571,21 +571,21 @@ typedef struct GetStatusResponse_Masternode__storage_ {
 
 @end
 
-int32_t GetStatusResponse_Masternode_State_RawValue(GetStatusResponse_Masternode *message) {
+int32_t GetStatusResponse_Masternode_Status_RawValue(GetStatusResponse_Masternode *message) {
   GPBDescriptor *descriptor = [GetStatusResponse_Masternode descriptor];
-  GPBFieldDescriptor *field = [descriptor fieldWithNumber:GetStatusResponse_Masternode_FieldNumber_State];
+  GPBFieldDescriptor *field = [descriptor fieldWithNumber:GetStatusResponse_Masternode_FieldNumber_Status];
   return GPBGetMessageInt32Field(message, field);
 }
 
-void SetGetStatusResponse_Masternode_State_RawValue(GetStatusResponse_Masternode *message, int32_t value) {
+void SetGetStatusResponse_Masternode_Status_RawValue(GetStatusResponse_Masternode *message, int32_t value) {
   GPBDescriptor *descriptor = [GetStatusResponse_Masternode descriptor];
-  GPBFieldDescriptor *field = [descriptor fieldWithNumber:GetStatusResponse_Masternode_FieldNumber_State];
+  GPBFieldDescriptor *field = [descriptor fieldWithNumber:GetStatusResponse_Masternode_FieldNumber_Status];
   GPBSetInt32IvarWithFieldInternal(message, field, value, descriptor.file.syntax);
 }
 
-#pragma mark - Enum GetStatusResponse_Masternode_State
+#pragma mark - Enum GetStatusResponse_Masternode_Status
 
-GPBEnumDescriptor *GetStatusResponse_Masternode_State_EnumDescriptor(void) {
+GPBEnumDescriptor *GetStatusResponse_Masternode_Status_EnumDescriptor(void) {
   static GPBEnumDescriptor *descriptor = NULL;
   if (!descriptor) {
     static const char *valueNames =
@@ -593,21 +593,21 @@ GPBEnumDescriptor *GetStatusResponse_Masternode_State_EnumDescriptor(void) {
         "ed\000OperatorKeyChanged\000ProtxIpChanged\000Rea"
         "dy\000Error\000";
     static const int32_t values[] = {
-        GetStatusResponse_Masternode_State_Unknown,
-        GetStatusResponse_Masternode_State_WaitingForProtx,
-        GetStatusResponse_Masternode_State_PoseBanned,
-        GetStatusResponse_Masternode_State_Removed,
-        GetStatusResponse_Masternode_State_OperatorKeyChanged,
-        GetStatusResponse_Masternode_State_ProtxIpChanged,
-        GetStatusResponse_Masternode_State_Ready,
-        GetStatusResponse_Masternode_State_Error,
+        GetStatusResponse_Masternode_Status_Unknown,
+        GetStatusResponse_Masternode_Status_WaitingForProtx,
+        GetStatusResponse_Masternode_Status_PoseBanned,
+        GetStatusResponse_Masternode_Status_Removed,
+        GetStatusResponse_Masternode_Status_OperatorKeyChanged,
+        GetStatusResponse_Masternode_Status_ProtxIpChanged,
+        GetStatusResponse_Masternode_Status_Ready,
+        GetStatusResponse_Masternode_Status_Error,
     };
     GPBEnumDescriptor *worker =
-        [GPBEnumDescriptor allocDescriptorForName:GPBNSStringifySymbol(GetStatusResponse_Masternode_State)
+        [GPBEnumDescriptor allocDescriptorForName:GPBNSStringifySymbol(GetStatusResponse_Masternode_Status)
                                        valueNames:valueNames
                                            values:values
                                             count:(uint32_t)(sizeof(values) / sizeof(int32_t))
-                                     enumVerifier:GetStatusResponse_Masternode_State_IsValidValue];
+                                     enumVerifier:GetStatusResponse_Masternode_Status_IsValidValue];
     if (!OSAtomicCompareAndSwapPtrBarrier(nil, worker, (void * volatile *)&descriptor)) {
       [worker release];
     }
@@ -615,16 +615,16 @@ GPBEnumDescriptor *GetStatusResponse_Masternode_State_EnumDescriptor(void) {
   return descriptor;
 }
 
-BOOL GetStatusResponse_Masternode_State_IsValidValue(int32_t value__) {
+BOOL GetStatusResponse_Masternode_Status_IsValidValue(int32_t value__) {
   switch (value__) {
-    case GetStatusResponse_Masternode_State_Unknown:
-    case GetStatusResponse_Masternode_State_WaitingForProtx:
-    case GetStatusResponse_Masternode_State_PoseBanned:
-    case GetStatusResponse_Masternode_State_Removed:
-    case GetStatusResponse_Masternode_State_OperatorKeyChanged:
-    case GetStatusResponse_Masternode_State_ProtxIpChanged:
-    case GetStatusResponse_Masternode_State_Ready:
-    case GetStatusResponse_Masternode_State_Error:
+    case GetStatusResponse_Masternode_Status_Unknown:
+    case GetStatusResponse_Masternode_Status_WaitingForProtx:
+    case GetStatusResponse_Masternode_Status_PoseBanned:
+    case GetStatusResponse_Masternode_Status_Removed:
+    case GetStatusResponse_Masternode_Status_OperatorKeyChanged:
+    case GetStatusResponse_Masternode_Status_ProtxIpChanged:
+    case GetStatusResponse_Masternode_Status_Ready:
+    case GetStatusResponse_Masternode_Status_Error:
       return YES;
     default:
       return NO;

--- a/clients/core/v0/objective-c/Core.pbobjc.m
+++ b/clients/core/v0/objective-c/Core.pbobjc.m
@@ -82,6 +82,7 @@ typedef struct GetStatusRequest__storage_ {
 @dynamic status;
 @dynamic syncProgress;
 @dynamic hasChain, chain;
+@dynamic hasMasternode, masternode;
 @dynamic hasNetwork, network;
 
 typedef struct GetStatusResponse__storage_ {
@@ -90,6 +91,7 @@ typedef struct GetStatusResponse__storage_ {
   GetStatusResponse_Version *version;
   GetStatusResponse_Time *time;
   GetStatusResponse_Chain *chain;
+  GetStatusResponse_Masternode *masternode;
   GetStatusResponse_Network *network;
   double syncProgress;
 } GetStatusResponse__storage_;
@@ -146,10 +148,19 @@ typedef struct GetStatusResponse__storage_ {
         .dataType = GPBDataTypeMessage,
       },
       {
+        .name = "masternode",
+        .dataTypeSpecific.className = GPBStringifySymbol(GetStatusResponse_Masternode),
+        .number = GetStatusResponse_FieldNumber_Masternode,
+        .hasIndex = 5,
+        .offset = (uint32_t)offsetof(GetStatusResponse__storage_, masternode),
+        .flags = GPBFieldOptional,
+        .dataType = GPBDataTypeMessage,
+      },
+      {
         .name = "network",
         .dataTypeSpecific.className = GPBStringifySymbol(GetStatusResponse_Network),
         .number = GetStatusResponse_FieldNumber_Network,
-        .hasIndex = 5,
+        .hasIndex = 6,
         .offset = (uint32_t)offsetof(GetStatusResponse__storage_, network),
         .flags = GPBFieldOptional,
         .dataType = GPBDataTypeMessage,
@@ -477,7 +488,7 @@ typedef struct GetStatusResponse_Chain__storage_ {
 
 @implementation GetStatusResponse_Masternode
 
-@dynamic status;
+@dynamic state;
 @dynamic proTxHash;
 @dynamic posePenalty;
 @dynamic isSynced;
@@ -485,7 +496,7 @@ typedef struct GetStatusResponse_Chain__storage_ {
 
 typedef struct GetStatusResponse_Masternode__storage_ {
   uint32_t _has_storage_[1];
-  GetStatusResponse_Masternode_Status status;
+  GetStatusResponse_Status state;
   uint32_t posePenalty;
   NSData *proTxHash;
   double syncProgress;
@@ -498,11 +509,11 @@ typedef struct GetStatusResponse_Masternode__storage_ {
   if (!descriptor) {
     static GPBMessageFieldDescription fields[] = {
       {
-        .name = "status",
-        .dataTypeSpecific.enumDescFunc = GetStatusResponse_Masternode_Status_EnumDescriptor,
-        .number = GetStatusResponse_Masternode_FieldNumber_Status,
+        .name = "state",
+        .dataTypeSpecific.enumDescFunc = GetStatusResponse_Status_EnumDescriptor,
+        .number = GetStatusResponse_Masternode_FieldNumber_State,
         .hasIndex = 0,
-        .offset = (uint32_t)offsetof(GetStatusResponse_Masternode__storage_, status),
+        .offset = (uint32_t)offsetof(GetStatusResponse_Masternode__storage_, state),
         .flags = (GPBFieldFlags)(GPBFieldOptional | GPBFieldHasEnumDescriptor),
         .dataType = GPBDataTypeEnum,
       },
@@ -560,21 +571,21 @@ typedef struct GetStatusResponse_Masternode__storage_ {
 
 @end
 
-int32_t GetStatusResponse_Masternode_Status_RawValue(GetStatusResponse_Masternode *message) {
+int32_t GetStatusResponse_Masternode_State_RawValue(GetStatusResponse_Masternode *message) {
   GPBDescriptor *descriptor = [GetStatusResponse_Masternode descriptor];
-  GPBFieldDescriptor *field = [descriptor fieldWithNumber:GetStatusResponse_Masternode_FieldNumber_Status];
+  GPBFieldDescriptor *field = [descriptor fieldWithNumber:GetStatusResponse_Masternode_FieldNumber_State];
   return GPBGetMessageInt32Field(message, field);
 }
 
-void SetGetStatusResponse_Masternode_Status_RawValue(GetStatusResponse_Masternode *message, int32_t value) {
+void SetGetStatusResponse_Masternode_State_RawValue(GetStatusResponse_Masternode *message, int32_t value) {
   GPBDescriptor *descriptor = [GetStatusResponse_Masternode descriptor];
-  GPBFieldDescriptor *field = [descriptor fieldWithNumber:GetStatusResponse_Masternode_FieldNumber_Status];
+  GPBFieldDescriptor *field = [descriptor fieldWithNumber:GetStatusResponse_Masternode_FieldNumber_State];
   GPBSetInt32IvarWithFieldInternal(message, field, value, descriptor.file.syntax);
 }
 
-#pragma mark - Enum GetStatusResponse_Masternode_Status
+#pragma mark - Enum GetStatusResponse_Masternode_State
 
-GPBEnumDescriptor *GetStatusResponse_Masternode_Status_EnumDescriptor(void) {
+GPBEnumDescriptor *GetStatusResponse_Masternode_State_EnumDescriptor(void) {
   static GPBEnumDescriptor *descriptor = NULL;
   if (!descriptor) {
     static const char *valueNames =
@@ -582,21 +593,21 @@ GPBEnumDescriptor *GetStatusResponse_Masternode_Status_EnumDescriptor(void) {
         "ed\000OperatorKeyChanged\000ProtxIpChanged\000Rea"
         "dy\000Error\000";
     static const int32_t values[] = {
-        GetStatusResponse_Masternode_Status_Unknown,
-        GetStatusResponse_Masternode_Status_WaitingForProtx,
-        GetStatusResponse_Masternode_Status_PoseBanned,
-        GetStatusResponse_Masternode_Status_Removed,
-        GetStatusResponse_Masternode_Status_OperatorKeyChanged,
-        GetStatusResponse_Masternode_Status_ProtxIpChanged,
-        GetStatusResponse_Masternode_Status_Ready,
-        GetStatusResponse_Masternode_Status_Error,
+        GetStatusResponse_Masternode_State_Unknown,
+        GetStatusResponse_Masternode_State_WaitingForProtx,
+        GetStatusResponse_Masternode_State_PoseBanned,
+        GetStatusResponse_Masternode_State_Removed,
+        GetStatusResponse_Masternode_State_OperatorKeyChanged,
+        GetStatusResponse_Masternode_State_ProtxIpChanged,
+        GetStatusResponse_Masternode_State_Ready,
+        GetStatusResponse_Masternode_State_Error,
     };
     GPBEnumDescriptor *worker =
-        [GPBEnumDescriptor allocDescriptorForName:GPBNSStringifySymbol(GetStatusResponse_Masternode_Status)
+        [GPBEnumDescriptor allocDescriptorForName:GPBNSStringifySymbol(GetStatusResponse_Masternode_State)
                                        valueNames:valueNames
                                            values:values
                                             count:(uint32_t)(sizeof(values) / sizeof(int32_t))
-                                     enumVerifier:GetStatusResponse_Masternode_Status_IsValidValue];
+                                     enumVerifier:GetStatusResponse_Masternode_State_IsValidValue];
     if (!OSAtomicCompareAndSwapPtrBarrier(nil, worker, (void * volatile *)&descriptor)) {
       [worker release];
     }
@@ -604,16 +615,16 @@ GPBEnumDescriptor *GetStatusResponse_Masternode_Status_EnumDescriptor(void) {
   return descriptor;
 }
 
-BOOL GetStatusResponse_Masternode_Status_IsValidValue(int32_t value__) {
+BOOL GetStatusResponse_Masternode_State_IsValidValue(int32_t value__) {
   switch (value__) {
-    case GetStatusResponse_Masternode_Status_Unknown:
-    case GetStatusResponse_Masternode_Status_WaitingForProtx:
-    case GetStatusResponse_Masternode_Status_PoseBanned:
-    case GetStatusResponse_Masternode_Status_Removed:
-    case GetStatusResponse_Masternode_Status_OperatorKeyChanged:
-    case GetStatusResponse_Masternode_Status_ProtxIpChanged:
-    case GetStatusResponse_Masternode_Status_Ready:
-    case GetStatusResponse_Masternode_Status_Error:
+    case GetStatusResponse_Masternode_State_Unknown:
+    case GetStatusResponse_Masternode_State_WaitingForProtx:
+    case GetStatusResponse_Masternode_State_PoseBanned:
+    case GetStatusResponse_Masternode_State_Removed:
+    case GetStatusResponse_Masternode_State_OperatorKeyChanged:
+    case GetStatusResponse_Masternode_State_ProtxIpChanged:
+    case GetStatusResponse_Masternode_State_Ready:
+    case GetStatusResponse_Masternode_State_Error:
       return YES;
     default:
       return NO;

--- a/clients/core/v0/objective-c/Core.pbobjc.m
+++ b/clients/core/v0/objective-c/Core.pbobjc.m
@@ -77,30 +77,21 @@ typedef struct GetStatusRequest__storage_ {
 
 @implementation GetStatusResponse
 
-@dynamic coreVersion;
-@dynamic protocolVersion;
-@dynamic blocks;
-@dynamic timeOffset;
-@dynamic connections;
-@dynamic proxy;
-@dynamic difficulty;
-@dynamic testnet;
-@dynamic relayFee;
-@dynamic errors;
-@dynamic network;
+@dynamic hasVersion, version;
+@dynamic hasTime, time;
+@dynamic status;
+@dynamic syncProgress;
+@dynamic hasChain, chain;
+@dynamic hasNetwork, network;
 
 typedef struct GetStatusResponse__storage_ {
   uint32_t _has_storage_[1];
-  uint32_t coreVersion;
-  uint32_t protocolVersion;
-  uint32_t blocks;
-  uint32_t timeOffset;
-  uint32_t connections;
-  NSString *proxy;
-  NSString *errors;
-  NSString *network;
-  double difficulty;
-  double relayFee;
+  GetStatusResponse_Status status;
+  GetStatusResponse_Version *version;
+  GetStatusResponse_Time *time;
+  GetStatusResponse_Chain *chain;
+  GetStatusResponse_Network *network;
+  double syncProgress;
 } GetStatusResponse__storage_;
 
 // This method is threadsafe because it is initially called
@@ -110,103 +101,58 @@ typedef struct GetStatusResponse__storage_ {
   if (!descriptor) {
     static GPBMessageFieldDescription fields[] = {
       {
-        .name = "coreVersion",
-        .dataTypeSpecific.className = NULL,
-        .number = GetStatusResponse_FieldNumber_CoreVersion,
+        .name = "version",
+        .dataTypeSpecific.className = GPBStringifySymbol(GetStatusResponse_Version),
+        .number = GetStatusResponse_FieldNumber_Version,
         .hasIndex = 0,
-        .offset = (uint32_t)offsetof(GetStatusResponse__storage_, coreVersion),
+        .offset = (uint32_t)offsetof(GetStatusResponse__storage_, version),
         .flags = GPBFieldOptional,
-        .dataType = GPBDataTypeUInt32,
+        .dataType = GPBDataTypeMessage,
       },
       {
-        .name = "protocolVersion",
-        .dataTypeSpecific.className = NULL,
-        .number = GetStatusResponse_FieldNumber_ProtocolVersion,
+        .name = "time",
+        .dataTypeSpecific.className = GPBStringifySymbol(GetStatusResponse_Time),
+        .number = GetStatusResponse_FieldNumber_Time,
         .hasIndex = 1,
-        .offset = (uint32_t)offsetof(GetStatusResponse__storage_, protocolVersion),
+        .offset = (uint32_t)offsetof(GetStatusResponse__storage_, time),
         .flags = GPBFieldOptional,
-        .dataType = GPBDataTypeUInt32,
+        .dataType = GPBDataTypeMessage,
       },
       {
-        .name = "blocks",
-        .dataTypeSpecific.className = NULL,
-        .number = GetStatusResponse_FieldNumber_Blocks,
+        .name = "status",
+        .dataTypeSpecific.enumDescFunc = GetStatusResponse_Status_EnumDescriptor,
+        .number = GetStatusResponse_FieldNumber_Status,
         .hasIndex = 2,
-        .offset = (uint32_t)offsetof(GetStatusResponse__storage_, blocks),
-        .flags = GPBFieldOptional,
-        .dataType = GPBDataTypeUInt32,
+        .offset = (uint32_t)offsetof(GetStatusResponse__storage_, status),
+        .flags = (GPBFieldFlags)(GPBFieldOptional | GPBFieldHasEnumDescriptor),
+        .dataType = GPBDataTypeEnum,
       },
       {
-        .name = "timeOffset",
+        .name = "syncProgress",
         .dataTypeSpecific.className = NULL,
-        .number = GetStatusResponse_FieldNumber_TimeOffset,
+        .number = GetStatusResponse_FieldNumber_SyncProgress,
         .hasIndex = 3,
-        .offset = (uint32_t)offsetof(GetStatusResponse__storage_, timeOffset),
+        .offset = (uint32_t)offsetof(GetStatusResponse__storage_, syncProgress),
         .flags = GPBFieldOptional,
-        .dataType = GPBDataTypeUInt32,
+        .dataType = GPBDataTypeDouble,
       },
       {
-        .name = "connections",
-        .dataTypeSpecific.className = NULL,
-        .number = GetStatusResponse_FieldNumber_Connections,
+        .name = "chain",
+        .dataTypeSpecific.className = GPBStringifySymbol(GetStatusResponse_Chain),
+        .number = GetStatusResponse_FieldNumber_Chain,
         .hasIndex = 4,
-        .offset = (uint32_t)offsetof(GetStatusResponse__storage_, connections),
+        .offset = (uint32_t)offsetof(GetStatusResponse__storage_, chain),
         .flags = GPBFieldOptional,
-        .dataType = GPBDataTypeUInt32,
-      },
-      {
-        .name = "proxy",
-        .dataTypeSpecific.className = NULL,
-        .number = GetStatusResponse_FieldNumber_Proxy,
-        .hasIndex = 5,
-        .offset = (uint32_t)offsetof(GetStatusResponse__storage_, proxy),
-        .flags = GPBFieldOptional,
-        .dataType = GPBDataTypeString,
-      },
-      {
-        .name = "difficulty",
-        .dataTypeSpecific.className = NULL,
-        .number = GetStatusResponse_FieldNumber_Difficulty,
-        .hasIndex = 6,
-        .offset = (uint32_t)offsetof(GetStatusResponse__storage_, difficulty),
-        .flags = GPBFieldOptional,
-        .dataType = GPBDataTypeDouble,
-      },
-      {
-        .name = "testnet",
-        .dataTypeSpecific.className = NULL,
-        .number = GetStatusResponse_FieldNumber_Testnet,
-        .hasIndex = 7,
-        .offset = 8,  // Stored in _has_storage_ to save space.
-        .flags = GPBFieldOptional,
-        .dataType = GPBDataTypeBool,
-      },
-      {
-        .name = "relayFee",
-        .dataTypeSpecific.className = NULL,
-        .number = GetStatusResponse_FieldNumber_RelayFee,
-        .hasIndex = 9,
-        .offset = (uint32_t)offsetof(GetStatusResponse__storage_, relayFee),
-        .flags = GPBFieldOptional,
-        .dataType = GPBDataTypeDouble,
-      },
-      {
-        .name = "errors",
-        .dataTypeSpecific.className = NULL,
-        .number = GetStatusResponse_FieldNumber_Errors,
-        .hasIndex = 10,
-        .offset = (uint32_t)offsetof(GetStatusResponse__storage_, errors),
-        .flags = GPBFieldOptional,
-        .dataType = GPBDataTypeString,
+        .dataType = GPBDataTypeMessage,
       },
       {
         .name = "network",
-        .dataTypeSpecific.className = NULL,
+        .dataTypeSpecific.className = GPBStringifySymbol(GetStatusResponse_Network),
         .number = GetStatusResponse_FieldNumber_Network,
-        .hasIndex = 11,
+        .hasIndex = 5,
         .offset = (uint32_t)offsetof(GetStatusResponse__storage_, network),
         .flags = GPBFieldOptional,
-        .dataType = GPBDataTypeString,
+        .dataType = GPBDataTypeMessage,
       },
     };
     GPBDescriptor *localDescriptor =
@@ -217,6 +163,567 @@ typedef struct GetStatusResponse__storage_ {
                                     fieldCount:(uint32_t)(sizeof(fields) / sizeof(GPBMessageFieldDescription))
                                    storageSize:sizeof(GetStatusResponse__storage_)
                                          flags:GPBDescriptorInitializationFlag_None];
+    NSAssert(descriptor == nil, @"Startup recursed!");
+    descriptor = localDescriptor;
+  }
+  return descriptor;
+}
+
+@end
+
+int32_t GetStatusResponse_Status_RawValue(GetStatusResponse *message) {
+  GPBDescriptor *descriptor = [GetStatusResponse descriptor];
+  GPBFieldDescriptor *field = [descriptor fieldWithNumber:GetStatusResponse_FieldNumber_Status];
+  return GPBGetMessageInt32Field(message, field);
+}
+
+void SetGetStatusResponse_Status_RawValue(GetStatusResponse *message, int32_t value) {
+  GPBDescriptor *descriptor = [GetStatusResponse descriptor];
+  GPBFieldDescriptor *field = [descriptor fieldWithNumber:GetStatusResponse_FieldNumber_Status];
+  GPBSetInt32IvarWithFieldInternal(message, field, value, descriptor.file.syntax);
+}
+
+#pragma mark - Enum GetStatusResponse_Status
+
+GPBEnumDescriptor *GetStatusResponse_Status_EnumDescriptor(void) {
+  static GPBEnumDescriptor *descriptor = NULL;
+  if (!descriptor) {
+    static const char *valueNames =
+        "Unknown\000NotStarted\000Syncing\000Ready\000";
+    static const int32_t values[] = {
+        GetStatusResponse_Status_Unknown,
+        GetStatusResponse_Status_NotStarted,
+        GetStatusResponse_Status_Syncing,
+        GetStatusResponse_Status_Ready,
+    };
+    GPBEnumDescriptor *worker =
+        [GPBEnumDescriptor allocDescriptorForName:GPBNSStringifySymbol(GetStatusResponse_Status)
+                                       valueNames:valueNames
+                                           values:values
+                                            count:(uint32_t)(sizeof(values) / sizeof(int32_t))
+                                     enumVerifier:GetStatusResponse_Status_IsValidValue];
+    if (!OSAtomicCompareAndSwapPtrBarrier(nil, worker, (void * volatile *)&descriptor)) {
+      [worker release];
+    }
+  }
+  return descriptor;
+}
+
+BOOL GetStatusResponse_Status_IsValidValue(int32_t value__) {
+  switch (value__) {
+    case GetStatusResponse_Status_Unknown:
+    case GetStatusResponse_Status_NotStarted:
+    case GetStatusResponse_Status_Syncing:
+    case GetStatusResponse_Status_Ready:
+      return YES;
+    default:
+      return NO;
+  }
+}
+
+#pragma mark - GetStatusResponse_Version
+
+@implementation GetStatusResponse_Version
+
+@dynamic protocol;
+@dynamic software;
+@dynamic agent;
+
+typedef struct GetStatusResponse_Version__storage_ {
+  uint32_t _has_storage_[1];
+  uint32_t protocol;
+  uint32_t software;
+  NSString *agent;
+} GetStatusResponse_Version__storage_;
+
+// This method is threadsafe because it is initially called
+// in +initialize for each subclass.
++ (GPBDescriptor *)descriptor {
+  static GPBDescriptor *descriptor = nil;
+  if (!descriptor) {
+    static GPBMessageFieldDescription fields[] = {
+      {
+        .name = "protocol",
+        .dataTypeSpecific.className = NULL,
+        .number = GetStatusResponse_Version_FieldNumber_Protocol,
+        .hasIndex = 0,
+        .offset = (uint32_t)offsetof(GetStatusResponse_Version__storage_, protocol),
+        .flags = GPBFieldOptional,
+        .dataType = GPBDataTypeUInt32,
+      },
+      {
+        .name = "software",
+        .dataTypeSpecific.className = NULL,
+        .number = GetStatusResponse_Version_FieldNumber_Software,
+        .hasIndex = 1,
+        .offset = (uint32_t)offsetof(GetStatusResponse_Version__storage_, software),
+        .flags = GPBFieldOptional,
+        .dataType = GPBDataTypeUInt32,
+      },
+      {
+        .name = "agent",
+        .dataTypeSpecific.className = NULL,
+        .number = GetStatusResponse_Version_FieldNumber_Agent,
+        .hasIndex = 2,
+        .offset = (uint32_t)offsetof(GetStatusResponse_Version__storage_, agent),
+        .flags = GPBFieldOptional,
+        .dataType = GPBDataTypeString,
+      },
+    };
+    GPBDescriptor *localDescriptor =
+        [GPBDescriptor allocDescriptorForClass:[GetStatusResponse_Version class]
+                                     rootClass:[CoreRoot class]
+                                          file:CoreRoot_FileDescriptor()
+                                        fields:fields
+                                    fieldCount:(uint32_t)(sizeof(fields) / sizeof(GPBMessageFieldDescription))
+                                   storageSize:sizeof(GetStatusResponse_Version__storage_)
+                                         flags:GPBDescriptorInitializationFlag_None];
+    [localDescriptor setupContainingMessageClassName:GPBStringifySymbol(GetStatusResponse)];
+    NSAssert(descriptor == nil, @"Startup recursed!");
+    descriptor = localDescriptor;
+  }
+  return descriptor;
+}
+
+@end
+
+#pragma mark - GetStatusResponse_Time
+
+@implementation GetStatusResponse_Time
+
+@dynamic now;
+@dynamic offset;
+@dynamic median;
+
+typedef struct GetStatusResponse_Time__storage_ {
+  uint32_t _has_storage_[1];
+  uint32_t now;
+  int32_t offset;
+  uint32_t median;
+} GetStatusResponse_Time__storage_;
+
+// This method is threadsafe because it is initially called
+// in +initialize for each subclass.
++ (GPBDescriptor *)descriptor {
+  static GPBDescriptor *descriptor = nil;
+  if (!descriptor) {
+    static GPBMessageFieldDescription fields[] = {
+      {
+        .name = "now",
+        .dataTypeSpecific.className = NULL,
+        .number = GetStatusResponse_Time_FieldNumber_Now,
+        .hasIndex = 0,
+        .offset = (uint32_t)offsetof(GetStatusResponse_Time__storage_, now),
+        .flags = GPBFieldOptional,
+        .dataType = GPBDataTypeUInt32,
+      },
+      {
+        .name = "offset",
+        .dataTypeSpecific.className = NULL,
+        .number = GetStatusResponse_Time_FieldNumber_Offset,
+        .hasIndex = 1,
+        .offset = (uint32_t)offsetof(GetStatusResponse_Time__storage_, offset),
+        .flags = GPBFieldOptional,
+        .dataType = GPBDataTypeInt32,
+      },
+      {
+        .name = "median",
+        .dataTypeSpecific.className = NULL,
+        .number = GetStatusResponse_Time_FieldNumber_Median,
+        .hasIndex = 2,
+        .offset = (uint32_t)offsetof(GetStatusResponse_Time__storage_, median),
+        .flags = GPBFieldOptional,
+        .dataType = GPBDataTypeUInt32,
+      },
+    };
+    GPBDescriptor *localDescriptor =
+        [GPBDescriptor allocDescriptorForClass:[GetStatusResponse_Time class]
+                                     rootClass:[CoreRoot class]
+                                          file:CoreRoot_FileDescriptor()
+                                        fields:fields
+                                    fieldCount:(uint32_t)(sizeof(fields) / sizeof(GPBMessageFieldDescription))
+                                   storageSize:sizeof(GetStatusResponse_Time__storage_)
+                                         flags:GPBDescriptorInitializationFlag_None];
+    [localDescriptor setupContainingMessageClassName:GPBStringifySymbol(GetStatusResponse)];
+    NSAssert(descriptor == nil, @"Startup recursed!");
+    descriptor = localDescriptor;
+  }
+  return descriptor;
+}
+
+@end
+
+#pragma mark - GetStatusResponse_Chain
+
+@implementation GetStatusResponse_Chain
+
+@dynamic name;
+@dynamic headersCount;
+@dynamic blocksCount;
+@dynamic bestBlockHash;
+@dynamic difficulty;
+@dynamic chainWork;
+@dynamic isSynced;
+@dynamic syncProgress;
+
+typedef struct GetStatusResponse_Chain__storage_ {
+  uint32_t _has_storage_[1];
+  uint32_t headersCount;
+  uint32_t blocksCount;
+  NSString *name;
+  NSData *bestBlockHash;
+  NSData *chainWork;
+  double difficulty;
+  double syncProgress;
+} GetStatusResponse_Chain__storage_;
+
+// This method is threadsafe because it is initially called
+// in +initialize for each subclass.
++ (GPBDescriptor *)descriptor {
+  static GPBDescriptor *descriptor = nil;
+  if (!descriptor) {
+    static GPBMessageFieldDescription fields[] = {
+      {
+        .name = "name",
+        .dataTypeSpecific.className = NULL,
+        .number = GetStatusResponse_Chain_FieldNumber_Name,
+        .hasIndex = 0,
+        .offset = (uint32_t)offsetof(GetStatusResponse_Chain__storage_, name),
+        .flags = GPBFieldOptional,
+        .dataType = GPBDataTypeString,
+      },
+      {
+        .name = "headersCount",
+        .dataTypeSpecific.className = NULL,
+        .number = GetStatusResponse_Chain_FieldNumber_HeadersCount,
+        .hasIndex = 1,
+        .offset = (uint32_t)offsetof(GetStatusResponse_Chain__storage_, headersCount),
+        .flags = GPBFieldOptional,
+        .dataType = GPBDataTypeUInt32,
+      },
+      {
+        .name = "blocksCount",
+        .dataTypeSpecific.className = NULL,
+        .number = GetStatusResponse_Chain_FieldNumber_BlocksCount,
+        .hasIndex = 2,
+        .offset = (uint32_t)offsetof(GetStatusResponse_Chain__storage_, blocksCount),
+        .flags = GPBFieldOptional,
+        .dataType = GPBDataTypeUInt32,
+      },
+      {
+        .name = "bestBlockHash",
+        .dataTypeSpecific.className = NULL,
+        .number = GetStatusResponse_Chain_FieldNumber_BestBlockHash,
+        .hasIndex = 3,
+        .offset = (uint32_t)offsetof(GetStatusResponse_Chain__storage_, bestBlockHash),
+        .flags = GPBFieldOptional,
+        .dataType = GPBDataTypeBytes,
+      },
+      {
+        .name = "difficulty",
+        .dataTypeSpecific.className = NULL,
+        .number = GetStatusResponse_Chain_FieldNumber_Difficulty,
+        .hasIndex = 4,
+        .offset = (uint32_t)offsetof(GetStatusResponse_Chain__storage_, difficulty),
+        .flags = GPBFieldOptional,
+        .dataType = GPBDataTypeDouble,
+      },
+      {
+        .name = "chainWork",
+        .dataTypeSpecific.className = NULL,
+        .number = GetStatusResponse_Chain_FieldNumber_ChainWork,
+        .hasIndex = 5,
+        .offset = (uint32_t)offsetof(GetStatusResponse_Chain__storage_, chainWork),
+        .flags = GPBFieldOptional,
+        .dataType = GPBDataTypeBytes,
+      },
+      {
+        .name = "isSynced",
+        .dataTypeSpecific.className = NULL,
+        .number = GetStatusResponse_Chain_FieldNumber_IsSynced,
+        .hasIndex = 6,
+        .offset = 7,  // Stored in _has_storage_ to save space.
+        .flags = GPBFieldOptional,
+        .dataType = GPBDataTypeBool,
+      },
+      {
+        .name = "syncProgress",
+        .dataTypeSpecific.className = NULL,
+        .number = GetStatusResponse_Chain_FieldNumber_SyncProgress,
+        .hasIndex = 8,
+        .offset = (uint32_t)offsetof(GetStatusResponse_Chain__storage_, syncProgress),
+        .flags = GPBFieldOptional,
+        .dataType = GPBDataTypeDouble,
+      },
+    };
+    GPBDescriptor *localDescriptor =
+        [GPBDescriptor allocDescriptorForClass:[GetStatusResponse_Chain class]
+                                     rootClass:[CoreRoot class]
+                                          file:CoreRoot_FileDescriptor()
+                                        fields:fields
+                                    fieldCount:(uint32_t)(sizeof(fields) / sizeof(GPBMessageFieldDescription))
+                                   storageSize:sizeof(GetStatusResponse_Chain__storage_)
+                                         flags:GPBDescriptorInitializationFlag_None];
+    [localDescriptor setupContainingMessageClassName:GPBStringifySymbol(GetStatusResponse)];
+    NSAssert(descriptor == nil, @"Startup recursed!");
+    descriptor = localDescriptor;
+  }
+  return descriptor;
+}
+
+@end
+
+#pragma mark - GetStatusResponse_Masternode
+
+@implementation GetStatusResponse_Masternode
+
+@dynamic status;
+@dynamic proTxHash;
+@dynamic posePenalty;
+@dynamic isSynced;
+@dynamic syncStatus;
+
+typedef struct GetStatusResponse_Masternode__storage_ {
+  uint32_t _has_storage_[1];
+  uint32_t posePenalty;
+  GetStatusResponse_Masternode_SyncStatus syncStatus;
+  NSString *status;
+  NSData *proTxHash;
+} GetStatusResponse_Masternode__storage_;
+
+// This method is threadsafe because it is initially called
+// in +initialize for each subclass.
++ (GPBDescriptor *)descriptor {
+  static GPBDescriptor *descriptor = nil;
+  if (!descriptor) {
+    static GPBMessageFieldDescription fields[] = {
+      {
+        .name = "status",
+        .dataTypeSpecific.className = NULL,
+        .number = GetStatusResponse_Masternode_FieldNumber_Status,
+        .hasIndex = 0,
+        .offset = (uint32_t)offsetof(GetStatusResponse_Masternode__storage_, status),
+        .flags = GPBFieldOptional,
+        .dataType = GPBDataTypeString,
+      },
+      {
+        .name = "proTxHash",
+        .dataTypeSpecific.className = NULL,
+        .number = GetStatusResponse_Masternode_FieldNumber_ProTxHash,
+        .hasIndex = 1,
+        .offset = (uint32_t)offsetof(GetStatusResponse_Masternode__storage_, proTxHash),
+        .flags = GPBFieldOptional,
+        .dataType = GPBDataTypeBytes,
+      },
+      {
+        .name = "posePenalty",
+        .dataTypeSpecific.className = NULL,
+        .number = GetStatusResponse_Masternode_FieldNumber_PosePenalty,
+        .hasIndex = 2,
+        .offset = (uint32_t)offsetof(GetStatusResponse_Masternode__storage_, posePenalty),
+        .flags = (GPBFieldFlags)(GPBFieldOptional | GPBFieldTextFormatNameCustom),
+        .dataType = GPBDataTypeUInt32,
+      },
+      {
+        .name = "isSynced",
+        .dataTypeSpecific.className = NULL,
+        .number = GetStatusResponse_Masternode_FieldNumber_IsSynced,
+        .hasIndex = 3,
+        .offset = 4,  // Stored in _has_storage_ to save space.
+        .flags = GPBFieldOptional,
+        .dataType = GPBDataTypeBool,
+      },
+      {
+        .name = "syncStatus",
+        .dataTypeSpecific.enumDescFunc = GetStatusResponse_Masternode_SyncStatus_EnumDescriptor,
+        .number = GetStatusResponse_Masternode_FieldNumber_SyncStatus,
+        .hasIndex = 5,
+        .offset = (uint32_t)offsetof(GetStatusResponse_Masternode__storage_, syncStatus),
+        .flags = (GPBFieldFlags)(GPBFieldOptional | GPBFieldHasEnumDescriptor),
+        .dataType = GPBDataTypeEnum,
+      },
+    };
+    GPBDescriptor *localDescriptor =
+        [GPBDescriptor allocDescriptorForClass:[GetStatusResponse_Masternode class]
+                                     rootClass:[CoreRoot class]
+                                          file:CoreRoot_FileDescriptor()
+                                        fields:fields
+                                    fieldCount:(uint32_t)(sizeof(fields) / sizeof(GPBMessageFieldDescription))
+                                   storageSize:sizeof(GetStatusResponse_Masternode__storage_)
+                                         flags:GPBDescriptorInitializationFlag_None];
+#if !GPBOBJC_SKIP_MESSAGE_TEXTFORMAT_EXTRAS
+    static const char *extraTextFormatInfo =
+        "\001\003\013\000";
+    [localDescriptor setupExtraTextInfo:extraTextFormatInfo];
+#endif  // !GPBOBJC_SKIP_MESSAGE_TEXTFORMAT_EXTRAS
+    [localDescriptor setupContainingMessageClassName:GPBStringifySymbol(GetStatusResponse)];
+    NSAssert(descriptor == nil, @"Startup recursed!");
+    descriptor = localDescriptor;
+  }
+  return descriptor;
+}
+
+@end
+
+int32_t GetStatusResponse_Masternode_SyncStatus_RawValue(GetStatusResponse_Masternode *message) {
+  GPBDescriptor *descriptor = [GetStatusResponse_Masternode descriptor];
+  GPBFieldDescriptor *field = [descriptor fieldWithNumber:GetStatusResponse_Masternode_FieldNumber_SyncStatus];
+  return GPBGetMessageInt32Field(message, field);
+}
+
+void SetGetStatusResponse_Masternode_SyncStatus_RawValue(GetStatusResponse_Masternode *message, int32_t value) {
+  GPBDescriptor *descriptor = [GetStatusResponse_Masternode descriptor];
+  GPBFieldDescriptor *field = [descriptor fieldWithNumber:GetStatusResponse_Masternode_FieldNumber_SyncStatus];
+  GPBSetInt32IvarWithFieldInternal(message, field, value, descriptor.file.syntax);
+}
+
+#pragma mark - Enum GetStatusResponse_Masternode_SyncStatus
+
+GPBEnumDescriptor *GetStatusResponse_Masternode_SyncStatus_EnumDescriptor(void) {
+  static GPBEnumDescriptor *descriptor = NULL;
+  if (!descriptor) {
+    static const char *valueNames =
+        "Unknown\000MasternodeSyncBlockchain\000Mastern"
+        "odeSyncGovernance\000MasternodeSyncFinished"
+        "\000";
+    static const int32_t values[] = {
+        GetStatusResponse_Masternode_SyncStatus_Unknown,
+        GetStatusResponse_Masternode_SyncStatus_MasternodeSyncBlockchain,
+        GetStatusResponse_Masternode_SyncStatus_MasternodeSyncGovernance,
+        GetStatusResponse_Masternode_SyncStatus_MasternodeSyncFinished,
+    };
+    GPBEnumDescriptor *worker =
+        [GPBEnumDescriptor allocDescriptorForName:GPBNSStringifySymbol(GetStatusResponse_Masternode_SyncStatus)
+                                       valueNames:valueNames
+                                           values:values
+                                            count:(uint32_t)(sizeof(values) / sizeof(int32_t))
+                                     enumVerifier:GetStatusResponse_Masternode_SyncStatus_IsValidValue];
+    if (!OSAtomicCompareAndSwapPtrBarrier(nil, worker, (void * volatile *)&descriptor)) {
+      [worker release];
+    }
+  }
+  return descriptor;
+}
+
+BOOL GetStatusResponse_Masternode_SyncStatus_IsValidValue(int32_t value__) {
+  switch (value__) {
+    case GetStatusResponse_Masternode_SyncStatus_Unknown:
+    case GetStatusResponse_Masternode_SyncStatus_MasternodeSyncBlockchain:
+    case GetStatusResponse_Masternode_SyncStatus_MasternodeSyncGovernance:
+    case GetStatusResponse_Masternode_SyncStatus_MasternodeSyncFinished:
+      return YES;
+    default:
+      return NO;
+  }
+}
+
+#pragma mark - GetStatusResponse_Network
+
+@implementation GetStatusResponse_Network
+
+@dynamic peersCount;
+@dynamic hasFee, fee;
+
+typedef struct GetStatusResponse_Network__storage_ {
+  uint32_t _has_storage_[1];
+  uint32_t peersCount;
+  GetStatusResponse_Network_Fee *fee;
+} GetStatusResponse_Network__storage_;
+
+// This method is threadsafe because it is initially called
+// in +initialize for each subclass.
++ (GPBDescriptor *)descriptor {
+  static GPBDescriptor *descriptor = nil;
+  if (!descriptor) {
+    static GPBMessageFieldDescription fields[] = {
+      {
+        .name = "peersCount",
+        .dataTypeSpecific.className = NULL,
+        .number = GetStatusResponse_Network_FieldNumber_PeersCount,
+        .hasIndex = 0,
+        .offset = (uint32_t)offsetof(GetStatusResponse_Network__storage_, peersCount),
+        .flags = (GPBFieldFlags)(GPBFieldOptional | GPBFieldTextFormatNameCustom),
+        .dataType = GPBDataTypeUInt32,
+      },
+      {
+        .name = "fee",
+        .dataTypeSpecific.className = GPBStringifySymbol(GetStatusResponse_Network_Fee),
+        .number = GetStatusResponse_Network_FieldNumber_Fee,
+        .hasIndex = 1,
+        .offset = (uint32_t)offsetof(GetStatusResponse_Network__storage_, fee),
+        .flags = GPBFieldOptional,
+        .dataType = GPBDataTypeMessage,
+      },
+    };
+    GPBDescriptor *localDescriptor =
+        [GPBDescriptor allocDescriptorForClass:[GetStatusResponse_Network class]
+                                     rootClass:[CoreRoot class]
+                                          file:CoreRoot_FileDescriptor()
+                                        fields:fields
+                                    fieldCount:(uint32_t)(sizeof(fields) / sizeof(GPBMessageFieldDescription))
+                                   storageSize:sizeof(GetStatusResponse_Network__storage_)
+                                         flags:GPBDescriptorInitializationFlag_None];
+#if !GPBOBJC_SKIP_MESSAGE_TEXTFORMAT_EXTRAS
+    static const char *extraTextFormatInfo =
+        "\001\001\n\000";
+    [localDescriptor setupExtraTextInfo:extraTextFormatInfo];
+#endif  // !GPBOBJC_SKIP_MESSAGE_TEXTFORMAT_EXTRAS
+    [localDescriptor setupContainingMessageClassName:GPBStringifySymbol(GetStatusResponse)];
+    NSAssert(descriptor == nil, @"Startup recursed!");
+    descriptor = localDescriptor;
+  }
+  return descriptor;
+}
+
+@end
+
+#pragma mark - GetStatusResponse_Network_Fee
+
+@implementation GetStatusResponse_Network_Fee
+
+@dynamic relay;
+@dynamic incremental;
+
+typedef struct GetStatusResponse_Network_Fee__storage_ {
+  uint32_t _has_storage_[1];
+  double relay;
+  double incremental;
+} GetStatusResponse_Network_Fee__storage_;
+
+// This method is threadsafe because it is initially called
+// in +initialize for each subclass.
++ (GPBDescriptor *)descriptor {
+  static GPBDescriptor *descriptor = nil;
+  if (!descriptor) {
+    static GPBMessageFieldDescription fields[] = {
+      {
+        .name = "relay",
+        .dataTypeSpecific.className = NULL,
+        .number = GetStatusResponse_Network_Fee_FieldNumber_Relay,
+        .hasIndex = 0,
+        .offset = (uint32_t)offsetof(GetStatusResponse_Network_Fee__storage_, relay),
+        .flags = GPBFieldOptional,
+        .dataType = GPBDataTypeDouble,
+      },
+      {
+        .name = "incremental",
+        .dataTypeSpecific.className = NULL,
+        .number = GetStatusResponse_Network_Fee_FieldNumber_Incremental,
+        .hasIndex = 1,
+        .offset = (uint32_t)offsetof(GetStatusResponse_Network_Fee__storage_, incremental),
+        .flags = GPBFieldOptional,
+        .dataType = GPBDataTypeDouble,
+      },
+    };
+    GPBDescriptor *localDescriptor =
+        [GPBDescriptor allocDescriptorForClass:[GetStatusResponse_Network_Fee class]
+                                     rootClass:[CoreRoot class]
+                                          file:CoreRoot_FileDescriptor()
+                                        fields:fields
+                                    fieldCount:(uint32_t)(sizeof(fields) / sizeof(GPBMessageFieldDescription))
+                                   storageSize:sizeof(GetStatusResponse_Network_Fee__storage_)
+                                         flags:GPBDescriptorInitializationFlag_None];
+    [localDescriptor setupContainingMessageClassName:GPBStringifySymbol(GetStatusResponse_Network)];
     NSAssert(descriptor == nil, @"Startup recursed!");
     descriptor = localDescriptor;
   }

--- a/clients/core/v0/python/core_pb2.py
+++ b/clients/core/v0/python/core_pb2.py
@@ -19,7 +19,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='core.proto',
   package='org.dash.platform.dapi.v0',
   syntax='proto3',
-  serialized_pb=_b('\n\ncore.proto\x12\x19org.dash.platform.dapi.v0\"\x12\n\x10GetStatusRequest\"\x89\n\n\x11GetStatusResponse\x12\x45\n\x07version\x18\x01 \x01(\x0b\x32\x34.org.dash.platform.dapi.v0.GetStatusResponse.Version\x12?\n\x04time\x18\x02 \x01(\x0b\x32\x31.org.dash.platform.dapi.v0.GetStatusResponse.Time\x12\x43\n\x06status\x18\x03 \x01(\x0e\x32\x33.org.dash.platform.dapi.v0.GetStatusResponse.Status\x12\x15\n\rsync_progress\x18\x04 \x01(\x01\x12\x41\n\x05\x63hain\x18\x05 \x01(\x0b\x32\x32.org.dash.platform.dapi.v0.GetStatusResponse.Chain\x12K\n\nmasternode\x18\x06 \x01(\x0b\x32\x37.org.dash.platform.dapi.v0.GetStatusResponse.Masternode\x12\x45\n\x07network\x18\x07 \x01(\x0b\x32\x34.org.dash.platform.dapi.v0.GetStatusResponse.Network\x1a<\n\x07Version\x12\x10\n\x08protocol\x18\x01 \x01(\r\x12\x10\n\x08software\x18\x02 \x01(\r\x12\r\n\x05\x61gent\x18\x03 \x01(\t\x1a\x33\n\x04Time\x12\x0b\n\x03now\x18\x01 \x01(\r\x12\x0e\n\x06offset\x18\x02 \x01(\x05\x12\x0e\n\x06median\x18\x03 \x01(\r\x1a\xad\x01\n\x05\x43hain\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x15\n\rheaders_count\x18\x02 \x01(\r\x12\x14\n\x0c\x62locks_count\x18\x03 \x01(\r\x12\x17\n\x0f\x62\x65st_block_hash\x18\x04 \x01(\x0c\x12\x12\n\ndifficulty\x18\x05 \x01(\x01\x12\x12\n\nchain_work\x18\x06 \x01(\x0c\x12\x11\n\tis_synced\x18\x07 \x01(\x08\x12\x15\n\rsync_progress\x18\x08 \x01(\x01\x1a\xc4\x02\n\nMasternode\x12N\n\x06status\x18\x01 \x01(\x0e\x32>.org.dash.platform.dapi.v0.GetStatusResponse.Masternode.Status\x12\x13\n\x0bpro_tx_hash\x18\x02 \x01(\x0c\x12\x14\n\x0cpose_penalty\x18\x03 \x01(\r\x12\x11\n\tis_synced\x18\x04 \x01(\x08\x12\x15\n\rsync_progress\x18\x05 \x01(\x01\"\x90\x01\n\x06Status\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x15\n\x11WAITING_FOR_PROTX\x10\x01\x12\x0f\n\x0bPOSE_BANNED\x10\x02\x12\x0b\n\x07REMOVED\x10\x03\x12\x18\n\x14OPERATOR_KEY_CHANGED\x10\x04\x12\x14\n\x10PROTX_IP_CHANGED\x10\x05\x12\t\n\x05READY\x10\x06\x12\t\n\x05\x45RROR\x10\x07\x1a\x90\x01\n\x07Network\x12\x13\n\x0bpeers_count\x18\x01 \x01(\r\x12\x45\n\x03\x66\x65\x65\x18\x02 \x01(\x0b\x32\x38.org.dash.platform.dapi.v0.GetStatusResponse.Network.Fee\x1a)\n\x03\x46\x65\x65\x12\r\n\x05relay\x18\x01 \x01(\x01\x12\x13\n\x0bincremental\x18\x02 \x01(\x01\"<\n\x06Status\x12\x0f\n\x0bNOT_STARTED\x10\x00\x12\x0b\n\x07SYNCING\x10\x01\x12\t\n\x05READY\x10\x02\x12\t\n\x05\x45RROR\x10\x03\"<\n\x0fGetBlockRequest\x12\x10\n\x06height\x18\x01 \x01(\rH\x00\x12\x0e\n\x04hash\x18\x02 \x01(\tH\x00\x42\x07\n\x05\x62lock\"!\n\x10GetBlockResponse\x12\r\n\x05\x62lock\x18\x01 \x01(\x0c\"b\n\x1b\x42roadcastTransactionRequest\x12\x13\n\x0btransaction\x18\x01 \x01(\x0c\x12\x17\n\x0f\x61llow_high_fees\x18\x02 \x01(\x08\x12\x15\n\rbypass_limits\x18\x03 \x01(\x08\"6\n\x1c\x42roadcastTransactionResponse\x12\x16\n\x0etransaction_id\x18\x01 \x01(\t\"#\n\x15GetTransactionRequest\x12\n\n\x02id\x18\x01 \x01(\t\"-\n\x16GetTransactionResponse\x12\x13\n\x0btransaction\x18\x01 \x01(\x0c\"x\n!BlockHeadersWithChainLocksRequest\x12\x19\n\x0f\x66rom_block_hash\x18\x01 \x01(\x0cH\x00\x12\x1b\n\x11\x66rom_block_height\x18\x02 \x01(\rH\x00\x12\r\n\x05\x63ount\x18\x03 \x01(\rB\x0c\n\nfrom_block\"\xd3\x01\n\"BlockHeadersWithChainLocksResponse\x12@\n\rblock_headers\x18\x01 \x01(\x0b\x32\'.org.dash.platform.dapi.v0.BlockHeadersH\x00\x12^\n\x1d\x63hain_lock_signature_messages\x18\x02 \x01(\x0b\x32\x35.org.dash.platform.dapi.v0.ChainLockSignatureMessagesH\x00\x42\x0b\n\tresponses\"\x1f\n\x0c\x42lockHeaders\x12\x0f\n\x07headers\x18\x01 \x03(\x0c\".\n\x1a\x43hainLockSignatureMessages\x12\x10\n\x08messages\x18\x01 \x03(\x0c\"3\n!GetEstimatedTransactionFeeRequest\x12\x0e\n\x06\x62locks\x18\x01 \x01(\r\"1\n\"GetEstimatedTransactionFeeResponse\x12\x0b\n\x03\x66\x65\x65\x18\x01 \x01(\x01\"\xd3\x01\n\x1dTransactionsWithProofsRequest\x12<\n\x0c\x62loom_filter\x18\x01 \x01(\x0b\x32&.org.dash.platform.dapi.v0.BloomFilter\x12\x19\n\x0f\x66rom_block_hash\x18\x02 \x01(\x0cH\x00\x12\x1b\n\x11\x66rom_block_height\x18\x03 \x01(\rH\x00\x12\r\n\x05\x63ount\x18\x04 \x01(\r\x12\x1f\n\x17send_transaction_hashes\x18\x05 \x01(\x08\x42\x0c\n\nfrom_block\"U\n\x0b\x42loomFilter\x12\x0e\n\x06v_data\x18\x01 \x01(\x0c\x12\x14\n\x0cn_hash_funcs\x18\x02 \x01(\r\x12\x0f\n\x07n_tweak\x18\x03 \x01(\r\x12\x0f\n\x07n_flags\x18\x04 \x01(\r\"\xeb\x01\n\x1eTransactionsWithProofsResponse\x12\x46\n\x10raw_transactions\x18\x01 \x01(\x0b\x32*.org.dash.platform.dapi.v0.RawTransactionsH\x00\x12X\n\x1ainstant_send_lock_messages\x18\x02 \x01(\x0b\x32\x32.org.dash.platform.dapi.v0.InstantSendLockMessagesH\x00\x12\x1a\n\x10raw_merkle_block\x18\x03 \x01(\x0cH\x00\x42\x0b\n\tresponses\"\'\n\x0fRawTransactions\x12\x14\n\x0ctransactions\x18\x01 \x03(\x0c\"+\n\x17InstantSendLockMessages\x12\x10\n\x08messages\x18\x01 \x03(\x0c\x32\xb6\x07\n\x04\x43ore\x12\x66\n\tgetStatus\x12+.org.dash.platform.dapi.v0.GetStatusRequest\x1a,.org.dash.platform.dapi.v0.GetStatusResponse\x12\x63\n\x08getBlock\x12*.org.dash.platform.dapi.v0.GetBlockRequest\x1a+.org.dash.platform.dapi.v0.GetBlockResponse\x12\x87\x01\n\x14\x62roadcastTransaction\x12\x36.org.dash.platform.dapi.v0.BroadcastTransactionRequest\x1a\x37.org.dash.platform.dapi.v0.BroadcastTransactionResponse\x12u\n\x0egetTransaction\x12\x30.org.dash.platform.dapi.v0.GetTransactionRequest\x1a\x31.org.dash.platform.dapi.v0.GetTransactionResponse\x12\x99\x01\n\x1agetEstimatedTransactionFee\x12<.org.dash.platform.dapi.v0.GetEstimatedTransactionFeeRequest\x1a=.org.dash.platform.dapi.v0.GetEstimatedTransactionFeeResponse\x12\xa6\x01\n%subscribeToBlockHeadersWithChainLocks\x12<.org.dash.platform.dapi.v0.BlockHeadersWithChainLocksRequest\x1a=.org.dash.platform.dapi.v0.BlockHeadersWithChainLocksResponse0\x01\x12\x9a\x01\n!subscribeToTransactionsWithProofs\x12\x38.org.dash.platform.dapi.v0.TransactionsWithProofsRequest\x1a\x39.org.dash.platform.dapi.v0.TransactionsWithProofsResponse0\x01\x62\x06proto3')
+  serialized_pb=_b('\n\ncore.proto\x12\x19org.dash.platform.dapi.v0\"\x12\n\x10GetStatusRequest\"\x80\n\n\x11GetStatusResponse\x12\x45\n\x07version\x18\x01 \x01(\x0b\x32\x34.org.dash.platform.dapi.v0.GetStatusResponse.Version\x12?\n\x04time\x18\x02 \x01(\x0b\x32\x31.org.dash.platform.dapi.v0.GetStatusResponse.Time\x12\x43\n\x06status\x18\x03 \x01(\x0e\x32\x33.org.dash.platform.dapi.v0.GetStatusResponse.Status\x12\x15\n\rsync_progress\x18\x04 \x01(\x01\x12\x41\n\x05\x63hain\x18\x05 \x01(\x0b\x32\x32.org.dash.platform.dapi.v0.GetStatusResponse.Chain\x12K\n\nmasternode\x18\x06 \x01(\x0b\x32\x37.org.dash.platform.dapi.v0.GetStatusResponse.Masternode\x12\x45\n\x07network\x18\x07 \x01(\x0b\x32\x34.org.dash.platform.dapi.v0.GetStatusResponse.Network\x1a<\n\x07Version\x12\x10\n\x08protocol\x18\x01 \x01(\r\x12\x10\n\x08software\x18\x02 \x01(\r\x12\r\n\x05\x61gent\x18\x03 \x01(\t\x1a\x33\n\x04Time\x12\x0b\n\x03now\x18\x01 \x01(\r\x12\x0e\n\x06offset\x18\x02 \x01(\x05\x12\x0e\n\x06median\x18\x03 \x01(\r\x1a\xad\x01\n\x05\x43hain\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x15\n\rheaders_count\x18\x02 \x01(\r\x12\x14\n\x0c\x62locks_count\x18\x03 \x01(\r\x12\x17\n\x0f\x62\x65st_block_hash\x18\x04 \x01(\x0c\x12\x12\n\ndifficulty\x18\x05 \x01(\x01\x12\x12\n\nchain_work\x18\x06 \x01(\x0c\x12\x11\n\tis_synced\x18\x07 \x01(\x08\x12\x15\n\rsync_progress\x18\x08 \x01(\x01\x1a\xc4\x02\n\nMasternode\x12N\n\x06status\x18\x01 \x01(\x0e\x32>.org.dash.platform.dapi.v0.GetStatusResponse.Masternode.Status\x12\x13\n\x0bpro_tx_hash\x18\x02 \x01(\x0c\x12\x14\n\x0cpose_penalty\x18\x03 \x01(\r\x12\x11\n\tis_synced\x18\x04 \x01(\x08\x12\x15\n\rsync_progress\x18\x05 \x01(\x01\"\x90\x01\n\x06Status\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x15\n\x11WAITING_FOR_PROTX\x10\x01\x12\x0f\n\x0bPOSE_BANNED\x10\x02\x12\x0b\n\x07REMOVED\x10\x03\x12\x18\n\x14OPERATOR_KEY_CHANGED\x10\x04\x12\x14\n\x10PROTX_IP_CHANGED\x10\x05\x12\t\n\x05READY\x10\x06\x12\t\n\x05\x45RROR\x10\x07\x1a)\n\x03\x46\x65\x65\x12\r\n\x05relay\x18\x01 \x01(\x01\x12\x13\n\x0bincremental\x18\x02 \x01(\x01\x1a]\n\x07Network\x12\x13\n\x0bpeers_count\x18\x01 \x01(\r\x12=\n\x03\x66\x65\x65\x18\x02 \x01(\x0b\x32\x30.org.dash.platform.dapi.v0.GetStatusResponse.Fee\"<\n\x06Status\x12\x0f\n\x0bNOT_STARTED\x10\x00\x12\x0b\n\x07SYNCING\x10\x01\x12\t\n\x05READY\x10\x02\x12\t\n\x05\x45RROR\x10\x03\"<\n\x0fGetBlockRequest\x12\x10\n\x06height\x18\x01 \x01(\rH\x00\x12\x0e\n\x04hash\x18\x02 \x01(\tH\x00\x42\x07\n\x05\x62lock\"!\n\x10GetBlockResponse\x12\r\n\x05\x62lock\x18\x01 \x01(\x0c\"b\n\x1b\x42roadcastTransactionRequest\x12\x13\n\x0btransaction\x18\x01 \x01(\x0c\x12\x17\n\x0f\x61llow_high_fees\x18\x02 \x01(\x08\x12\x15\n\rbypass_limits\x18\x03 \x01(\x08\"6\n\x1c\x42roadcastTransactionResponse\x12\x16\n\x0etransaction_id\x18\x01 \x01(\t\"#\n\x15GetTransactionRequest\x12\n\n\x02id\x18\x01 \x01(\t\"-\n\x16GetTransactionResponse\x12\x13\n\x0btransaction\x18\x01 \x01(\x0c\"x\n!BlockHeadersWithChainLocksRequest\x12\x19\n\x0f\x66rom_block_hash\x18\x01 \x01(\x0cH\x00\x12\x1b\n\x11\x66rom_block_height\x18\x02 \x01(\rH\x00\x12\r\n\x05\x63ount\x18\x03 \x01(\rB\x0c\n\nfrom_block\"\xd3\x01\n\"BlockHeadersWithChainLocksResponse\x12@\n\rblock_headers\x18\x01 \x01(\x0b\x32\'.org.dash.platform.dapi.v0.BlockHeadersH\x00\x12^\n\x1d\x63hain_lock_signature_messages\x18\x02 \x01(\x0b\x32\x35.org.dash.platform.dapi.v0.ChainLockSignatureMessagesH\x00\x42\x0b\n\tresponses\"\x1f\n\x0c\x42lockHeaders\x12\x0f\n\x07headers\x18\x01 \x03(\x0c\".\n\x1a\x43hainLockSignatureMessages\x12\x10\n\x08messages\x18\x01 \x03(\x0c\"3\n!GetEstimatedTransactionFeeRequest\x12\x0e\n\x06\x62locks\x18\x01 \x01(\r\"1\n\"GetEstimatedTransactionFeeResponse\x12\x0b\n\x03\x66\x65\x65\x18\x01 \x01(\x01\"\xd3\x01\n\x1dTransactionsWithProofsRequest\x12<\n\x0c\x62loom_filter\x18\x01 \x01(\x0b\x32&.org.dash.platform.dapi.v0.BloomFilter\x12\x19\n\x0f\x66rom_block_hash\x18\x02 \x01(\x0cH\x00\x12\x1b\n\x11\x66rom_block_height\x18\x03 \x01(\rH\x00\x12\r\n\x05\x63ount\x18\x04 \x01(\r\x12\x1f\n\x17send_transaction_hashes\x18\x05 \x01(\x08\x42\x0c\n\nfrom_block\"U\n\x0b\x42loomFilter\x12\x0e\n\x06v_data\x18\x01 \x01(\x0c\x12\x14\n\x0cn_hash_funcs\x18\x02 \x01(\r\x12\x0f\n\x07n_tweak\x18\x03 \x01(\r\x12\x0f\n\x07n_flags\x18\x04 \x01(\r\"\xeb\x01\n\x1eTransactionsWithProofsResponse\x12\x46\n\x10raw_transactions\x18\x01 \x01(\x0b\x32*.org.dash.platform.dapi.v0.RawTransactionsH\x00\x12X\n\x1ainstant_send_lock_messages\x18\x02 \x01(\x0b\x32\x32.org.dash.platform.dapi.v0.InstantSendLockMessagesH\x00\x12\x1a\n\x10raw_merkle_block\x18\x03 \x01(\x0cH\x00\x42\x0b\n\tresponses\"\'\n\x0fRawTransactions\x12\x14\n\x0ctransactions\x18\x01 \x03(\x0c\"+\n\x17InstantSendLockMessages\x12\x10\n\x08messages\x18\x01 \x03(\x0c\x32\xb6\x07\n\x04\x43ore\x12\x66\n\tgetStatus\x12+.org.dash.platform.dapi.v0.GetStatusRequest\x1a,.org.dash.platform.dapi.v0.GetStatusResponse\x12\x63\n\x08getBlock\x12*.org.dash.platform.dapi.v0.GetBlockRequest\x1a+.org.dash.platform.dapi.v0.GetBlockResponse\x12\x87\x01\n\x14\x62roadcastTransaction\x12\x36.org.dash.platform.dapi.v0.BroadcastTransactionRequest\x1a\x37.org.dash.platform.dapi.v0.BroadcastTransactionResponse\x12u\n\x0egetTransaction\x12\x30.org.dash.platform.dapi.v0.GetTransactionRequest\x1a\x31.org.dash.platform.dapi.v0.GetTransactionResponse\x12\x99\x01\n\x1agetEstimatedTransactionFee\x12<.org.dash.platform.dapi.v0.GetEstimatedTransactionFeeRequest\x1a=.org.dash.platform.dapi.v0.GetEstimatedTransactionFeeResponse\x12\xa6\x01\n%subscribeToBlockHeadersWithChainLocks\x12<.org.dash.platform.dapi.v0.BlockHeadersWithChainLocksRequest\x1a=.org.dash.platform.dapi.v0.BlockHeadersWithChainLocksResponse0\x01\x12\x9a\x01\n!subscribeToTransactionsWithProofs\x12\x38.org.dash.platform.dapi.v0.TransactionsWithProofsRequest\x1a\x39.org.dash.platform.dapi.v0.TransactionsWithProofsResponse0\x01\x62\x06proto3')
 )
 
 
@@ -95,8 +95,8 @@ _GETSTATUSRESPONSE_STATUS = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=1291,
-  serialized_end=1351,
+  serialized_start=1282,
+  serialized_end=1342,
 )
 _sym_db.RegisterEnumDescriptor(_GETSTATUSRESPONSE_STATUS)
 
@@ -351,22 +351,22 @@ _GETSTATUSRESPONSE_MASTERNODE = _descriptor.Descriptor(
   serialized_end=1142,
 )
 
-_GETSTATUSRESPONSE_NETWORK_FEE = _descriptor.Descriptor(
+_GETSTATUSRESPONSE_FEE = _descriptor.Descriptor(
   name='Fee',
-  full_name='org.dash.platform.dapi.v0.GetStatusResponse.Network.Fee',
+  full_name='org.dash.platform.dapi.v0.GetStatusResponse.Fee',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='relay', full_name='org.dash.platform.dapi.v0.GetStatusResponse.Network.Fee.relay', index=0,
+      name='relay', full_name='org.dash.platform.dapi.v0.GetStatusResponse.Fee.relay', index=0,
       number=1, type=1, cpp_type=5, label=1,
       has_default_value=False, default_value=float(0),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='incremental', full_name='org.dash.platform.dapi.v0.GetStatusResponse.Network.Fee.incremental', index=1,
+      name='incremental', full_name='org.dash.platform.dapi.v0.GetStatusResponse.Fee.incremental', index=1,
       number=2, type=1, cpp_type=5, label=1,
       has_default_value=False, default_value=float(0),
       message_type=None, enum_type=None, containing_type=None,
@@ -384,8 +384,8 @@ _GETSTATUSRESPONSE_NETWORK_FEE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1248,
-  serialized_end=1289,
+  serialized_start=1144,
+  serialized_end=1185,
 )
 
 _GETSTATUSRESPONSE_NETWORK = _descriptor.Descriptor(
@@ -412,7 +412,7 @@ _GETSTATUSRESPONSE_NETWORK = _descriptor.Descriptor(
   ],
   extensions=[
   ],
-  nested_types=[_GETSTATUSRESPONSE_NETWORK_FEE, ],
+  nested_types=[],
   enum_types=[
   ],
   options=None,
@@ -421,8 +421,8 @@ _GETSTATUSRESPONSE_NETWORK = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1145,
-  serialized_end=1289,
+  serialized_start=1187,
+  serialized_end=1280,
 )
 
 _GETSTATUSRESPONSE = _descriptor.Descriptor(
@@ -484,7 +484,7 @@ _GETSTATUSRESPONSE = _descriptor.Descriptor(
   ],
   extensions=[
   ],
-  nested_types=[_GETSTATUSRESPONSE_VERSION, _GETSTATUSRESPONSE_TIME, _GETSTATUSRESPONSE_CHAIN, _GETSTATUSRESPONSE_MASTERNODE, _GETSTATUSRESPONSE_NETWORK, ],
+  nested_types=[_GETSTATUSRESPONSE_VERSION, _GETSTATUSRESPONSE_TIME, _GETSTATUSRESPONSE_CHAIN, _GETSTATUSRESPONSE_MASTERNODE, _GETSTATUSRESPONSE_FEE, _GETSTATUSRESPONSE_NETWORK, ],
   enum_types=[
     _GETSTATUSRESPONSE_STATUS,
   ],
@@ -495,7 +495,7 @@ _GETSTATUSRESPONSE = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=62,
-  serialized_end=1351,
+  serialized_end=1342,
 )
 
 
@@ -535,8 +535,8 @@ _GETBLOCKREQUEST = _descriptor.Descriptor(
       name='block', full_name='org.dash.platform.dapi.v0.GetBlockRequest.block',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=1353,
-  serialized_end=1413,
+  serialized_start=1344,
+  serialized_end=1404,
 )
 
 
@@ -566,8 +566,8 @@ _GETBLOCKRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1415,
-  serialized_end=1448,
+  serialized_start=1406,
+  serialized_end=1439,
 )
 
 
@@ -611,8 +611,8 @@ _BROADCASTTRANSACTIONREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1450,
-  serialized_end=1548,
+  serialized_start=1441,
+  serialized_end=1539,
 )
 
 
@@ -642,8 +642,8 @@ _BROADCASTTRANSACTIONRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1550,
-  serialized_end=1604,
+  serialized_start=1541,
+  serialized_end=1595,
 )
 
 
@@ -673,8 +673,8 @@ _GETTRANSACTIONREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1606,
-  serialized_end=1641,
+  serialized_start=1597,
+  serialized_end=1632,
 )
 
 
@@ -704,8 +704,8 @@ _GETTRANSACTIONRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1643,
-  serialized_end=1688,
+  serialized_start=1634,
+  serialized_end=1679,
 )
 
 
@@ -752,8 +752,8 @@ _BLOCKHEADERSWITHCHAINLOCKSREQUEST = _descriptor.Descriptor(
       name='from_block', full_name='org.dash.platform.dapi.v0.BlockHeadersWithChainLocksRequest.from_block',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=1690,
-  serialized_end=1810,
+  serialized_start=1681,
+  serialized_end=1801,
 )
 
 
@@ -793,8 +793,8 @@ _BLOCKHEADERSWITHCHAINLOCKSRESPONSE = _descriptor.Descriptor(
       name='responses', full_name='org.dash.platform.dapi.v0.BlockHeadersWithChainLocksResponse.responses',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=1813,
-  serialized_end=2024,
+  serialized_start=1804,
+  serialized_end=2015,
 )
 
 
@@ -824,8 +824,8 @@ _BLOCKHEADERS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2026,
-  serialized_end=2057,
+  serialized_start=2017,
+  serialized_end=2048,
 )
 
 
@@ -855,8 +855,8 @@ _CHAINLOCKSIGNATUREMESSAGES = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2059,
-  serialized_end=2105,
+  serialized_start=2050,
+  serialized_end=2096,
 )
 
 
@@ -886,8 +886,8 @@ _GETESTIMATEDTRANSACTIONFEEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2107,
-  serialized_end=2158,
+  serialized_start=2098,
+  serialized_end=2149,
 )
 
 
@@ -917,8 +917,8 @@ _GETESTIMATEDTRANSACTIONFEERESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2160,
-  serialized_end=2209,
+  serialized_start=2151,
+  serialized_end=2200,
 )
 
 
@@ -979,8 +979,8 @@ _TRANSACTIONSWITHPROOFSREQUEST = _descriptor.Descriptor(
       name='from_block', full_name='org.dash.platform.dapi.v0.TransactionsWithProofsRequest.from_block',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=2212,
-  serialized_end=2423,
+  serialized_start=2203,
+  serialized_end=2414,
 )
 
 
@@ -1031,8 +1031,8 @@ _BLOOMFILTER = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2425,
-  serialized_end=2510,
+  serialized_start=2416,
+  serialized_end=2501,
 )
 
 
@@ -1079,8 +1079,8 @@ _TRANSACTIONSWITHPROOFSRESPONSE = _descriptor.Descriptor(
       name='responses', full_name='org.dash.platform.dapi.v0.TransactionsWithProofsResponse.responses',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=2513,
-  serialized_end=2748,
+  serialized_start=2504,
+  serialized_end=2739,
 )
 
 
@@ -1110,8 +1110,8 @@ _RAWTRANSACTIONS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2750,
-  serialized_end=2789,
+  serialized_start=2741,
+  serialized_end=2780,
 )
 
 
@@ -1141,8 +1141,8 @@ _INSTANTSENDLOCKMESSAGES = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2791,
-  serialized_end=2834,
+  serialized_start=2782,
+  serialized_end=2825,
 )
 
 _GETSTATUSRESPONSE_VERSION.containing_type = _GETSTATUSRESPONSE
@@ -1151,8 +1151,8 @@ _GETSTATUSRESPONSE_CHAIN.containing_type = _GETSTATUSRESPONSE
 _GETSTATUSRESPONSE_MASTERNODE.fields_by_name['status'].enum_type = _GETSTATUSRESPONSE_MASTERNODE_STATUS
 _GETSTATUSRESPONSE_MASTERNODE.containing_type = _GETSTATUSRESPONSE
 _GETSTATUSRESPONSE_MASTERNODE_STATUS.containing_type = _GETSTATUSRESPONSE_MASTERNODE
-_GETSTATUSRESPONSE_NETWORK_FEE.containing_type = _GETSTATUSRESPONSE_NETWORK
-_GETSTATUSRESPONSE_NETWORK.fields_by_name['fee'].message_type = _GETSTATUSRESPONSE_NETWORK_FEE
+_GETSTATUSRESPONSE_FEE.containing_type = _GETSTATUSRESPONSE
+_GETSTATUSRESPONSE_NETWORK.fields_by_name['fee'].message_type = _GETSTATUSRESPONSE_FEE
 _GETSTATUSRESPONSE_NETWORK.containing_type = _GETSTATUSRESPONSE
 _GETSTATUSRESPONSE.fields_by_name['version'].message_type = _GETSTATUSRESPONSE_VERSION
 _GETSTATUSRESPONSE.fields_by_name['time'].message_type = _GETSTATUSRESPONSE_TIME
@@ -1257,14 +1257,14 @@ GetStatusResponse = _reflection.GeneratedProtocolMessageType('GetStatusResponse'
     ))
   ,
 
-  Network = _reflection.GeneratedProtocolMessageType('Network', (_message.Message,), dict(
+  Fee = _reflection.GeneratedProtocolMessageType('Fee', (_message.Message,), dict(
+    DESCRIPTOR = _GETSTATUSRESPONSE_FEE,
+    __module__ = 'core_pb2'
+    # @@protoc_insertion_point(class_scope:org.dash.platform.dapi.v0.GetStatusResponse.Fee)
+    ))
+  ,
 
-    Fee = _reflection.GeneratedProtocolMessageType('Fee', (_message.Message,), dict(
-      DESCRIPTOR = _GETSTATUSRESPONSE_NETWORK_FEE,
-      __module__ = 'core_pb2'
-      # @@protoc_insertion_point(class_scope:org.dash.platform.dapi.v0.GetStatusResponse.Network.Fee)
-      ))
-    ,
+  Network = _reflection.GeneratedProtocolMessageType('Network', (_message.Message,), dict(
     DESCRIPTOR = _GETSTATUSRESPONSE_NETWORK,
     __module__ = 'core_pb2'
     # @@protoc_insertion_point(class_scope:org.dash.platform.dapi.v0.GetStatusResponse.Network)
@@ -1279,8 +1279,8 @@ _sym_db.RegisterMessage(GetStatusResponse.Version)
 _sym_db.RegisterMessage(GetStatusResponse.Time)
 _sym_db.RegisterMessage(GetStatusResponse.Chain)
 _sym_db.RegisterMessage(GetStatusResponse.Masternode)
+_sym_db.RegisterMessage(GetStatusResponse.Fee)
 _sym_db.RegisterMessage(GetStatusResponse.Network)
-_sym_db.RegisterMessage(GetStatusResponse.Network.Fee)
 
 GetBlockRequest = _reflection.GeneratedProtocolMessageType('GetBlockRequest', (_message.Message,), dict(
   DESCRIPTOR = _GETBLOCKREQUEST,
@@ -1409,8 +1409,8 @@ _CORE = _descriptor.ServiceDescriptor(
   file=DESCRIPTOR,
   index=0,
   options=None,
-  serialized_start=2837,
-  serialized_end=3787,
+  serialized_start=2828,
+  serialized_end=3778,
   methods=[
   _descriptor.MethodDescriptor(
     name='getStatus',

--- a/clients/core/v0/python/core_pb2.py
+++ b/clients/core/v0/python/core_pb2.py
@@ -19,14 +19,14 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='core.proto',
   package='org.dash.platform.dapi.v0',
   syntax='proto3',
-  serialized_pb=_b('\n\ncore.proto\x12\x19org.dash.platform.dapi.v0\"\x12\n\x10GetStatusRequest\"\xfc\t\n\x11GetStatusResponse\x12\x45\n\x07version\x18\x01 \x01(\x0b\x32\x34.org.dash.platform.dapi.v0.GetStatusResponse.Version\x12?\n\x04time\x18\x02 \x01(\x0b\x32\x31.org.dash.platform.dapi.v0.GetStatusResponse.Time\x12\x43\n\x06status\x18\x03 \x01(\x0e\x32\x33.org.dash.platform.dapi.v0.GetStatusResponse.Status\x12\x15\n\rsync_progress\x18\x04 \x01(\x01\x12\x41\n\x05\x63hain\x18\x05 \x01(\x0b\x32\x32.org.dash.platform.dapi.v0.GetStatusResponse.Chain\x12K\n\nmasternode\x18\x06 \x01(\x0b\x32\x37.org.dash.platform.dapi.v0.GetStatusResponse.Masternode\x12\x45\n\x07network\x18\x07 \x01(\x0b\x32\x34.org.dash.platform.dapi.v0.GetStatusResponse.Network\x1a<\n\x07Version\x12\x10\n\x08protocol\x18\x01 \x01(\r\x12\x10\n\x08software\x18\x02 \x01(\r\x12\r\n\x05\x61gent\x18\x03 \x01(\t\x1a\x33\n\x04Time\x12\x0b\n\x03now\x18\x01 \x01(\r\x12\x0e\n\x06offset\x18\x02 \x01(\x05\x12\x0e\n\x06median\x18\x03 \x01(\r\x1a\xad\x01\n\x05\x43hain\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x15\n\rheaders_count\x18\x02 \x01(\r\x12\x14\n\x0c\x62locks_count\x18\x03 \x01(\r\x12\x17\n\x0f\x62\x65st_block_hash\x18\x04 \x01(\x0c\x12\x12\n\ndifficulty\x18\x05 \x01(\x01\x12\x12\n\nchain_work\x18\x06 \x01(\x0c\x12\x11\n\tis_synced\x18\x07 \x01(\x08\x12\x15\n\rsync_progress\x18\x08 \x01(\x01\x1a\xb7\x02\n\nMasternode\x12\x42\n\x05state\x18\x01 \x01(\x0e\x32\x33.org.dash.platform.dapi.v0.GetStatusResponse.Status\x12\x13\n\x0bpro_tx_hash\x18\x02 \x01(\x0c\x12\x14\n\x0cpose_penalty\x18\x03 \x01(\r\x12\x11\n\tis_synced\x18\x04 \x01(\x08\x12\x15\n\rsync_progress\x18\x05 \x01(\x01\"\x8f\x01\n\x05State\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x15\n\x11WAITING_FOR_PROTX\x10\x01\x12\x0f\n\x0bPOSE_BANNED\x10\x02\x12\x0b\n\x07REMOVED\x10\x03\x12\x18\n\x14OPERATOR_KEY_CHANGED\x10\x04\x12\x14\n\x10PROTX_IP_CHANGED\x10\x05\x12\t\n\x05READY\x10\x06\x12\t\n\x05\x45RROR\x10\x07\x1a\x90\x01\n\x07Network\x12\x13\n\x0bpeers_count\x18\x01 \x01(\r\x12\x45\n\x03\x66\x65\x65\x18\x02 \x01(\x0b\x32\x38.org.dash.platform.dapi.v0.GetStatusResponse.Network.Fee\x1a)\n\x03\x46\x65\x65\x12\r\n\x05relay\x18\x01 \x01(\x01\x12\x13\n\x0bincremental\x18\x02 \x01(\x01\"<\n\x06Status\x12\x0f\n\x0bNOT_STARTED\x10\x00\x12\x0b\n\x07SYNCING\x10\x01\x12\t\n\x05READY\x10\x02\x12\t\n\x05\x45RROR\x10\x03\"<\n\x0fGetBlockRequest\x12\x10\n\x06height\x18\x01 \x01(\rH\x00\x12\x0e\n\x04hash\x18\x02 \x01(\tH\x00\x42\x07\n\x05\x62lock\"!\n\x10GetBlockResponse\x12\r\n\x05\x62lock\x18\x01 \x01(\x0c\"b\n\x1b\x42roadcastTransactionRequest\x12\x13\n\x0btransaction\x18\x01 \x01(\x0c\x12\x17\n\x0f\x61llow_high_fees\x18\x02 \x01(\x08\x12\x15\n\rbypass_limits\x18\x03 \x01(\x08\"6\n\x1c\x42roadcastTransactionResponse\x12\x16\n\x0etransaction_id\x18\x01 \x01(\t\"#\n\x15GetTransactionRequest\x12\n\n\x02id\x18\x01 \x01(\t\"-\n\x16GetTransactionResponse\x12\x13\n\x0btransaction\x18\x01 \x01(\x0c\"x\n!BlockHeadersWithChainLocksRequest\x12\x19\n\x0f\x66rom_block_hash\x18\x01 \x01(\x0cH\x00\x12\x1b\n\x11\x66rom_block_height\x18\x02 \x01(\rH\x00\x12\r\n\x05\x63ount\x18\x03 \x01(\rB\x0c\n\nfrom_block\"\xd3\x01\n\"BlockHeadersWithChainLocksResponse\x12@\n\rblock_headers\x18\x01 \x01(\x0b\x32\'.org.dash.platform.dapi.v0.BlockHeadersH\x00\x12^\n\x1d\x63hain_lock_signature_messages\x18\x02 \x01(\x0b\x32\x35.org.dash.platform.dapi.v0.ChainLockSignatureMessagesH\x00\x42\x0b\n\tresponses\"\x1f\n\x0c\x42lockHeaders\x12\x0f\n\x07headers\x18\x01 \x03(\x0c\".\n\x1a\x43hainLockSignatureMessages\x12\x10\n\x08messages\x18\x01 \x03(\x0c\"3\n!GetEstimatedTransactionFeeRequest\x12\x0e\n\x06\x62locks\x18\x01 \x01(\r\"1\n\"GetEstimatedTransactionFeeResponse\x12\x0b\n\x03\x66\x65\x65\x18\x01 \x01(\x01\"\xd3\x01\n\x1dTransactionsWithProofsRequest\x12<\n\x0c\x62loom_filter\x18\x01 \x01(\x0b\x32&.org.dash.platform.dapi.v0.BloomFilter\x12\x19\n\x0f\x66rom_block_hash\x18\x02 \x01(\x0cH\x00\x12\x1b\n\x11\x66rom_block_height\x18\x03 \x01(\rH\x00\x12\r\n\x05\x63ount\x18\x04 \x01(\r\x12\x1f\n\x17send_transaction_hashes\x18\x05 \x01(\x08\x42\x0c\n\nfrom_block\"U\n\x0b\x42loomFilter\x12\x0e\n\x06v_data\x18\x01 \x01(\x0c\x12\x14\n\x0cn_hash_funcs\x18\x02 \x01(\r\x12\x0f\n\x07n_tweak\x18\x03 \x01(\r\x12\x0f\n\x07n_flags\x18\x04 \x01(\r\"\xeb\x01\n\x1eTransactionsWithProofsResponse\x12\x46\n\x10raw_transactions\x18\x01 \x01(\x0b\x32*.org.dash.platform.dapi.v0.RawTransactionsH\x00\x12X\n\x1ainstant_send_lock_messages\x18\x02 \x01(\x0b\x32\x32.org.dash.platform.dapi.v0.InstantSendLockMessagesH\x00\x12\x1a\n\x10raw_merkle_block\x18\x03 \x01(\x0cH\x00\x42\x0b\n\tresponses\"\'\n\x0fRawTransactions\x12\x14\n\x0ctransactions\x18\x01 \x03(\x0c\"+\n\x17InstantSendLockMessages\x12\x10\n\x08messages\x18\x01 \x03(\x0c\x32\xb6\x07\n\x04\x43ore\x12\x66\n\tgetStatus\x12+.org.dash.platform.dapi.v0.GetStatusRequest\x1a,.org.dash.platform.dapi.v0.GetStatusResponse\x12\x63\n\x08getBlock\x12*.org.dash.platform.dapi.v0.GetBlockRequest\x1a+.org.dash.platform.dapi.v0.GetBlockResponse\x12\x87\x01\n\x14\x62roadcastTransaction\x12\x36.org.dash.platform.dapi.v0.BroadcastTransactionRequest\x1a\x37.org.dash.platform.dapi.v0.BroadcastTransactionResponse\x12u\n\x0egetTransaction\x12\x30.org.dash.platform.dapi.v0.GetTransactionRequest\x1a\x31.org.dash.platform.dapi.v0.GetTransactionResponse\x12\x99\x01\n\x1agetEstimatedTransactionFee\x12<.org.dash.platform.dapi.v0.GetEstimatedTransactionFeeRequest\x1a=.org.dash.platform.dapi.v0.GetEstimatedTransactionFeeResponse\x12\xa6\x01\n%subscribeToBlockHeadersWithChainLocks\x12<.org.dash.platform.dapi.v0.BlockHeadersWithChainLocksRequest\x1a=.org.dash.platform.dapi.v0.BlockHeadersWithChainLocksResponse0\x01\x12\x9a\x01\n!subscribeToTransactionsWithProofs\x12\x38.org.dash.platform.dapi.v0.TransactionsWithProofsRequest\x1a\x39.org.dash.platform.dapi.v0.TransactionsWithProofsResponse0\x01\x62\x06proto3')
+  serialized_pb=_b('\n\ncore.proto\x12\x19org.dash.platform.dapi.v0\"\x12\n\x10GetStatusRequest\"\x89\n\n\x11GetStatusResponse\x12\x45\n\x07version\x18\x01 \x01(\x0b\x32\x34.org.dash.platform.dapi.v0.GetStatusResponse.Version\x12?\n\x04time\x18\x02 \x01(\x0b\x32\x31.org.dash.platform.dapi.v0.GetStatusResponse.Time\x12\x43\n\x06status\x18\x03 \x01(\x0e\x32\x33.org.dash.platform.dapi.v0.GetStatusResponse.Status\x12\x15\n\rsync_progress\x18\x04 \x01(\x01\x12\x41\n\x05\x63hain\x18\x05 \x01(\x0b\x32\x32.org.dash.platform.dapi.v0.GetStatusResponse.Chain\x12K\n\nmasternode\x18\x06 \x01(\x0b\x32\x37.org.dash.platform.dapi.v0.GetStatusResponse.Masternode\x12\x45\n\x07network\x18\x07 \x01(\x0b\x32\x34.org.dash.platform.dapi.v0.GetStatusResponse.Network\x1a<\n\x07Version\x12\x10\n\x08protocol\x18\x01 \x01(\r\x12\x10\n\x08software\x18\x02 \x01(\r\x12\r\n\x05\x61gent\x18\x03 \x01(\t\x1a\x33\n\x04Time\x12\x0b\n\x03now\x18\x01 \x01(\r\x12\x0e\n\x06offset\x18\x02 \x01(\x05\x12\x0e\n\x06median\x18\x03 \x01(\r\x1a\xad\x01\n\x05\x43hain\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x15\n\rheaders_count\x18\x02 \x01(\r\x12\x14\n\x0c\x62locks_count\x18\x03 \x01(\r\x12\x17\n\x0f\x62\x65st_block_hash\x18\x04 \x01(\x0c\x12\x12\n\ndifficulty\x18\x05 \x01(\x01\x12\x12\n\nchain_work\x18\x06 \x01(\x0c\x12\x11\n\tis_synced\x18\x07 \x01(\x08\x12\x15\n\rsync_progress\x18\x08 \x01(\x01\x1a\xc4\x02\n\nMasternode\x12N\n\x06status\x18\x01 \x01(\x0e\x32>.org.dash.platform.dapi.v0.GetStatusResponse.Masternode.Status\x12\x13\n\x0bpro_tx_hash\x18\x02 \x01(\x0c\x12\x14\n\x0cpose_penalty\x18\x03 \x01(\r\x12\x11\n\tis_synced\x18\x04 \x01(\x08\x12\x15\n\rsync_progress\x18\x05 \x01(\x01\"\x90\x01\n\x06Status\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x15\n\x11WAITING_FOR_PROTX\x10\x01\x12\x0f\n\x0bPOSE_BANNED\x10\x02\x12\x0b\n\x07REMOVED\x10\x03\x12\x18\n\x14OPERATOR_KEY_CHANGED\x10\x04\x12\x14\n\x10PROTX_IP_CHANGED\x10\x05\x12\t\n\x05READY\x10\x06\x12\t\n\x05\x45RROR\x10\x07\x1a\x90\x01\n\x07Network\x12\x13\n\x0bpeers_count\x18\x01 \x01(\r\x12\x45\n\x03\x66\x65\x65\x18\x02 \x01(\x0b\x32\x38.org.dash.platform.dapi.v0.GetStatusResponse.Network.Fee\x1a)\n\x03\x46\x65\x65\x12\r\n\x05relay\x18\x01 \x01(\x01\x12\x13\n\x0bincremental\x18\x02 \x01(\x01\"<\n\x06Status\x12\x0f\n\x0bNOT_STARTED\x10\x00\x12\x0b\n\x07SYNCING\x10\x01\x12\t\n\x05READY\x10\x02\x12\t\n\x05\x45RROR\x10\x03\"<\n\x0fGetBlockRequest\x12\x10\n\x06height\x18\x01 \x01(\rH\x00\x12\x0e\n\x04hash\x18\x02 \x01(\tH\x00\x42\x07\n\x05\x62lock\"!\n\x10GetBlockResponse\x12\r\n\x05\x62lock\x18\x01 \x01(\x0c\"b\n\x1b\x42roadcastTransactionRequest\x12\x13\n\x0btransaction\x18\x01 \x01(\x0c\x12\x17\n\x0f\x61llow_high_fees\x18\x02 \x01(\x08\x12\x15\n\rbypass_limits\x18\x03 \x01(\x08\"6\n\x1c\x42roadcastTransactionResponse\x12\x16\n\x0etransaction_id\x18\x01 \x01(\t\"#\n\x15GetTransactionRequest\x12\n\n\x02id\x18\x01 \x01(\t\"-\n\x16GetTransactionResponse\x12\x13\n\x0btransaction\x18\x01 \x01(\x0c\"x\n!BlockHeadersWithChainLocksRequest\x12\x19\n\x0f\x66rom_block_hash\x18\x01 \x01(\x0cH\x00\x12\x1b\n\x11\x66rom_block_height\x18\x02 \x01(\rH\x00\x12\r\n\x05\x63ount\x18\x03 \x01(\rB\x0c\n\nfrom_block\"\xd3\x01\n\"BlockHeadersWithChainLocksResponse\x12@\n\rblock_headers\x18\x01 \x01(\x0b\x32\'.org.dash.platform.dapi.v0.BlockHeadersH\x00\x12^\n\x1d\x63hain_lock_signature_messages\x18\x02 \x01(\x0b\x32\x35.org.dash.platform.dapi.v0.ChainLockSignatureMessagesH\x00\x42\x0b\n\tresponses\"\x1f\n\x0c\x42lockHeaders\x12\x0f\n\x07headers\x18\x01 \x03(\x0c\".\n\x1a\x43hainLockSignatureMessages\x12\x10\n\x08messages\x18\x01 \x03(\x0c\"3\n!GetEstimatedTransactionFeeRequest\x12\x0e\n\x06\x62locks\x18\x01 \x01(\r\"1\n\"GetEstimatedTransactionFeeResponse\x12\x0b\n\x03\x66\x65\x65\x18\x01 \x01(\x01\"\xd3\x01\n\x1dTransactionsWithProofsRequest\x12<\n\x0c\x62loom_filter\x18\x01 \x01(\x0b\x32&.org.dash.platform.dapi.v0.BloomFilter\x12\x19\n\x0f\x66rom_block_hash\x18\x02 \x01(\x0cH\x00\x12\x1b\n\x11\x66rom_block_height\x18\x03 \x01(\rH\x00\x12\r\n\x05\x63ount\x18\x04 \x01(\r\x12\x1f\n\x17send_transaction_hashes\x18\x05 \x01(\x08\x42\x0c\n\nfrom_block\"U\n\x0b\x42loomFilter\x12\x0e\n\x06v_data\x18\x01 \x01(\x0c\x12\x14\n\x0cn_hash_funcs\x18\x02 \x01(\r\x12\x0f\n\x07n_tweak\x18\x03 \x01(\r\x12\x0f\n\x07n_flags\x18\x04 \x01(\r\"\xeb\x01\n\x1eTransactionsWithProofsResponse\x12\x46\n\x10raw_transactions\x18\x01 \x01(\x0b\x32*.org.dash.platform.dapi.v0.RawTransactionsH\x00\x12X\n\x1ainstant_send_lock_messages\x18\x02 \x01(\x0b\x32\x32.org.dash.platform.dapi.v0.InstantSendLockMessagesH\x00\x12\x1a\n\x10raw_merkle_block\x18\x03 \x01(\x0cH\x00\x42\x0b\n\tresponses\"\'\n\x0fRawTransactions\x12\x14\n\x0ctransactions\x18\x01 \x03(\x0c\"+\n\x17InstantSendLockMessages\x12\x10\n\x08messages\x18\x01 \x03(\x0c\x32\xb6\x07\n\x04\x43ore\x12\x66\n\tgetStatus\x12+.org.dash.platform.dapi.v0.GetStatusRequest\x1a,.org.dash.platform.dapi.v0.GetStatusResponse\x12\x63\n\x08getBlock\x12*.org.dash.platform.dapi.v0.GetBlockRequest\x1a+.org.dash.platform.dapi.v0.GetBlockResponse\x12\x87\x01\n\x14\x62roadcastTransaction\x12\x36.org.dash.platform.dapi.v0.BroadcastTransactionRequest\x1a\x37.org.dash.platform.dapi.v0.BroadcastTransactionResponse\x12u\n\x0egetTransaction\x12\x30.org.dash.platform.dapi.v0.GetTransactionRequest\x1a\x31.org.dash.platform.dapi.v0.GetTransactionResponse\x12\x99\x01\n\x1agetEstimatedTransactionFee\x12<.org.dash.platform.dapi.v0.GetEstimatedTransactionFeeRequest\x1a=.org.dash.platform.dapi.v0.GetEstimatedTransactionFeeResponse\x12\xa6\x01\n%subscribeToBlockHeadersWithChainLocks\x12<.org.dash.platform.dapi.v0.BlockHeadersWithChainLocksRequest\x1a=.org.dash.platform.dapi.v0.BlockHeadersWithChainLocksResponse0\x01\x12\x9a\x01\n!subscribeToTransactionsWithProofs\x12\x38.org.dash.platform.dapi.v0.TransactionsWithProofsRequest\x1a\x39.org.dash.platform.dapi.v0.TransactionsWithProofsResponse0\x01\x62\x06proto3')
 )
 
 
 
-_GETSTATUSRESPONSE_MASTERNODE_STATE = _descriptor.EnumDescriptor(
-  name='State',
-  full_name='org.dash.platform.dapi.v0.GetStatusResponse.Masternode.State',
+_GETSTATUSRESPONSE_MASTERNODE_STATUS = _descriptor.EnumDescriptor(
+  name='Status',
+  full_name='org.dash.platform.dapi.v0.GetStatusResponse.Masternode.Status',
   filename=None,
   file=DESCRIPTOR,
   values=[
@@ -65,10 +65,10 @@ _GETSTATUSRESPONSE_MASTERNODE_STATE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=986,
-  serialized_end=1129,
+  serialized_start=998,
+  serialized_end=1142,
 )
-_sym_db.RegisterEnumDescriptor(_GETSTATUSRESPONSE_MASTERNODE_STATE)
+_sym_db.RegisterEnumDescriptor(_GETSTATUSRESPONSE_MASTERNODE_STATUS)
 
 _GETSTATUSRESPONSE_STATUS = _descriptor.EnumDescriptor(
   name='Status',
@@ -95,8 +95,8 @@ _GETSTATUSRESPONSE_STATUS = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=1278,
-  serialized_end=1338,
+  serialized_start=1291,
+  serialized_end=1351,
 )
 _sym_db.RegisterEnumDescriptor(_GETSTATUSRESPONSE_STATUS)
 
@@ -300,7 +300,7 @@ _GETSTATUSRESPONSE_MASTERNODE = _descriptor.Descriptor(
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='state', full_name='org.dash.platform.dapi.v0.GetStatusResponse.Masternode.state', index=0,
+      name='status', full_name='org.dash.platform.dapi.v0.GetStatusResponse.Masternode.status', index=0,
       number=1, type=14, cpp_type=8, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
@@ -339,7 +339,7 @@ _GETSTATUSRESPONSE_MASTERNODE = _descriptor.Descriptor(
   ],
   nested_types=[],
   enum_types=[
-    _GETSTATUSRESPONSE_MASTERNODE_STATE,
+    _GETSTATUSRESPONSE_MASTERNODE_STATUS,
   ],
   options=None,
   is_extendable=False,
@@ -348,7 +348,7 @@ _GETSTATUSRESPONSE_MASTERNODE = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=818,
-  serialized_end=1129,
+  serialized_end=1142,
 )
 
 _GETSTATUSRESPONSE_NETWORK_FEE = _descriptor.Descriptor(
@@ -384,8 +384,8 @@ _GETSTATUSRESPONSE_NETWORK_FEE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1235,
-  serialized_end=1276,
+  serialized_start=1248,
+  serialized_end=1289,
 )
 
 _GETSTATUSRESPONSE_NETWORK = _descriptor.Descriptor(
@@ -421,8 +421,8 @@ _GETSTATUSRESPONSE_NETWORK = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1132,
-  serialized_end=1276,
+  serialized_start=1145,
+  serialized_end=1289,
 )
 
 _GETSTATUSRESPONSE = _descriptor.Descriptor(
@@ -495,7 +495,7 @@ _GETSTATUSRESPONSE = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=62,
-  serialized_end=1338,
+  serialized_end=1351,
 )
 
 
@@ -535,8 +535,8 @@ _GETBLOCKREQUEST = _descriptor.Descriptor(
       name='block', full_name='org.dash.platform.dapi.v0.GetBlockRequest.block',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=1340,
-  serialized_end=1400,
+  serialized_start=1353,
+  serialized_end=1413,
 )
 
 
@@ -566,8 +566,8 @@ _GETBLOCKRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1402,
-  serialized_end=1435,
+  serialized_start=1415,
+  serialized_end=1448,
 )
 
 
@@ -611,8 +611,8 @@ _BROADCASTTRANSACTIONREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1437,
-  serialized_end=1535,
+  serialized_start=1450,
+  serialized_end=1548,
 )
 
 
@@ -642,8 +642,8 @@ _BROADCASTTRANSACTIONRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1537,
-  serialized_end=1591,
+  serialized_start=1550,
+  serialized_end=1604,
 )
 
 
@@ -673,8 +673,8 @@ _GETTRANSACTIONREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1593,
-  serialized_end=1628,
+  serialized_start=1606,
+  serialized_end=1641,
 )
 
 
@@ -704,8 +704,8 @@ _GETTRANSACTIONRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1630,
-  serialized_end=1675,
+  serialized_start=1643,
+  serialized_end=1688,
 )
 
 
@@ -752,8 +752,8 @@ _BLOCKHEADERSWITHCHAINLOCKSREQUEST = _descriptor.Descriptor(
       name='from_block', full_name='org.dash.platform.dapi.v0.BlockHeadersWithChainLocksRequest.from_block',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=1677,
-  serialized_end=1797,
+  serialized_start=1690,
+  serialized_end=1810,
 )
 
 
@@ -793,8 +793,8 @@ _BLOCKHEADERSWITHCHAINLOCKSRESPONSE = _descriptor.Descriptor(
       name='responses', full_name='org.dash.platform.dapi.v0.BlockHeadersWithChainLocksResponse.responses',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=1800,
-  serialized_end=2011,
+  serialized_start=1813,
+  serialized_end=2024,
 )
 
 
@@ -824,8 +824,8 @@ _BLOCKHEADERS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2013,
-  serialized_end=2044,
+  serialized_start=2026,
+  serialized_end=2057,
 )
 
 
@@ -855,8 +855,8 @@ _CHAINLOCKSIGNATUREMESSAGES = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2046,
-  serialized_end=2092,
+  serialized_start=2059,
+  serialized_end=2105,
 )
 
 
@@ -886,8 +886,8 @@ _GETESTIMATEDTRANSACTIONFEEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2094,
-  serialized_end=2145,
+  serialized_start=2107,
+  serialized_end=2158,
 )
 
 
@@ -917,8 +917,8 @@ _GETESTIMATEDTRANSACTIONFEERESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2147,
-  serialized_end=2196,
+  serialized_start=2160,
+  serialized_end=2209,
 )
 
 
@@ -979,8 +979,8 @@ _TRANSACTIONSWITHPROOFSREQUEST = _descriptor.Descriptor(
       name='from_block', full_name='org.dash.platform.dapi.v0.TransactionsWithProofsRequest.from_block',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=2199,
-  serialized_end=2410,
+  serialized_start=2212,
+  serialized_end=2423,
 )
 
 
@@ -1031,8 +1031,8 @@ _BLOOMFILTER = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2412,
-  serialized_end=2497,
+  serialized_start=2425,
+  serialized_end=2510,
 )
 
 
@@ -1079,8 +1079,8 @@ _TRANSACTIONSWITHPROOFSRESPONSE = _descriptor.Descriptor(
       name='responses', full_name='org.dash.platform.dapi.v0.TransactionsWithProofsResponse.responses',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=2500,
-  serialized_end=2735,
+  serialized_start=2513,
+  serialized_end=2748,
 )
 
 
@@ -1110,8 +1110,8 @@ _RAWTRANSACTIONS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2737,
-  serialized_end=2776,
+  serialized_start=2750,
+  serialized_end=2789,
 )
 
 
@@ -1141,16 +1141,16 @@ _INSTANTSENDLOCKMESSAGES = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2778,
-  serialized_end=2821,
+  serialized_start=2791,
+  serialized_end=2834,
 )
 
 _GETSTATUSRESPONSE_VERSION.containing_type = _GETSTATUSRESPONSE
 _GETSTATUSRESPONSE_TIME.containing_type = _GETSTATUSRESPONSE
 _GETSTATUSRESPONSE_CHAIN.containing_type = _GETSTATUSRESPONSE
-_GETSTATUSRESPONSE_MASTERNODE.fields_by_name['state'].enum_type = _GETSTATUSRESPONSE_STATUS
+_GETSTATUSRESPONSE_MASTERNODE.fields_by_name['status'].enum_type = _GETSTATUSRESPONSE_MASTERNODE_STATUS
 _GETSTATUSRESPONSE_MASTERNODE.containing_type = _GETSTATUSRESPONSE
-_GETSTATUSRESPONSE_MASTERNODE_STATE.containing_type = _GETSTATUSRESPONSE_MASTERNODE
+_GETSTATUSRESPONSE_MASTERNODE_STATUS.containing_type = _GETSTATUSRESPONSE_MASTERNODE
 _GETSTATUSRESPONSE_NETWORK_FEE.containing_type = _GETSTATUSRESPONSE_NETWORK
 _GETSTATUSRESPONSE_NETWORK.fields_by_name['fee'].message_type = _GETSTATUSRESPONSE_NETWORK_FEE
 _GETSTATUSRESPONSE_NETWORK.containing_type = _GETSTATUSRESPONSE
@@ -1409,8 +1409,8 @@ _CORE = _descriptor.ServiceDescriptor(
   file=DESCRIPTOR,
   index=0,
   options=None,
-  serialized_start=2824,
-  serialized_end=3774,
+  serialized_start=2837,
+  serialized_end=3787,
   methods=[
   _descriptor.MethodDescriptor(
     name='getStatus',

--- a/clients/core/v0/python/core_pb2.py
+++ b/clients/core/v0/python/core_pb2.py
@@ -19,10 +19,70 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='core.proto',
   package='org.dash.platform.dapi.v0',
   syntax='proto3',
-  serialized_pb=_b('\n\ncore.proto\x12\x19org.dash.platform.dapi.v0\"\x12\n\x10GetStatusRequest\"\xe5\x01\n\x11GetStatusResponse\x12\x14\n\x0c\x63ore_version\x18\x01 \x01(\r\x12\x18\n\x10protocol_version\x18\x02 \x01(\r\x12\x0e\n\x06\x62locks\x18\x03 \x01(\r\x12\x13\n\x0btime_offset\x18\x04 \x01(\r\x12\x13\n\x0b\x63onnections\x18\x05 \x01(\r\x12\r\n\x05proxy\x18\x06 \x01(\t\x12\x12\n\ndifficulty\x18\x07 \x01(\x01\x12\x0f\n\x07testnet\x18\x08 \x01(\x08\x12\x11\n\trelay_fee\x18\t \x01(\x01\x12\x0e\n\x06\x65rrors\x18\n \x01(\t\x12\x0f\n\x07network\x18\x0b \x01(\t\"<\n\x0fGetBlockRequest\x12\x10\n\x06height\x18\x01 \x01(\rH\x00\x12\x0e\n\x04hash\x18\x02 \x01(\tH\x00\x42\x07\n\x05\x62lock\"!\n\x10GetBlockResponse\x12\r\n\x05\x62lock\x18\x01 \x01(\x0c\"b\n\x1b\x42roadcastTransactionRequest\x12\x13\n\x0btransaction\x18\x01 \x01(\x0c\x12\x17\n\x0f\x61llow_high_fees\x18\x02 \x01(\x08\x12\x15\n\rbypass_limits\x18\x03 \x01(\x08\"6\n\x1c\x42roadcastTransactionResponse\x12\x16\n\x0etransaction_id\x18\x01 \x01(\t\"#\n\x15GetTransactionRequest\x12\n\n\x02id\x18\x01 \x01(\t\"-\n\x16GetTransactionResponse\x12\x13\n\x0btransaction\x18\x01 \x01(\x0c\"x\n!BlockHeadersWithChainLocksRequest\x12\x19\n\x0f\x66rom_block_hash\x18\x01 \x01(\x0cH\x00\x12\x1b\n\x11\x66rom_block_height\x18\x02 \x01(\rH\x00\x12\r\n\x05\x63ount\x18\x03 \x01(\rB\x0c\n\nfrom_block\"\xd3\x01\n\"BlockHeadersWithChainLocksResponse\x12@\n\rblock_headers\x18\x01 \x01(\x0b\x32\'.org.dash.platform.dapi.v0.BlockHeadersH\x00\x12^\n\x1d\x63hain_lock_signature_messages\x18\x02 \x01(\x0b\x32\x35.org.dash.platform.dapi.v0.ChainLockSignatureMessagesH\x00\x42\x0b\n\tresponses\"\x1f\n\x0c\x42lockHeaders\x12\x0f\n\x07headers\x18\x01 \x03(\x0c\".\n\x1a\x43hainLockSignatureMessages\x12\x10\n\x08messages\x18\x01 \x03(\x0c\"3\n!GetEstimatedTransactionFeeRequest\x12\x0e\n\x06\x62locks\x18\x01 \x01(\r\"1\n\"GetEstimatedTransactionFeeResponse\x12\x0b\n\x03\x66\x65\x65\x18\x01 \x01(\x01\"\xd3\x01\n\x1dTransactionsWithProofsRequest\x12<\n\x0c\x62loom_filter\x18\x01 \x01(\x0b\x32&.org.dash.platform.dapi.v0.BloomFilter\x12\x19\n\x0f\x66rom_block_hash\x18\x02 \x01(\x0cH\x00\x12\x1b\n\x11\x66rom_block_height\x18\x03 \x01(\rH\x00\x12\r\n\x05\x63ount\x18\x04 \x01(\r\x12\x1f\n\x17send_transaction_hashes\x18\x05 \x01(\x08\x42\x0c\n\nfrom_block\"U\n\x0b\x42loomFilter\x12\x0e\n\x06v_data\x18\x01 \x01(\x0c\x12\x14\n\x0cn_hash_funcs\x18\x02 \x01(\r\x12\x0f\n\x07n_tweak\x18\x03 \x01(\r\x12\x0f\n\x07n_flags\x18\x04 \x01(\r\"\xeb\x01\n\x1eTransactionsWithProofsResponse\x12\x46\n\x10raw_transactions\x18\x01 \x01(\x0b\x32*.org.dash.platform.dapi.v0.RawTransactionsH\x00\x12X\n\x1ainstant_send_lock_messages\x18\x02 \x01(\x0b\x32\x32.org.dash.platform.dapi.v0.InstantSendLockMessagesH\x00\x12\x1a\n\x10raw_merkle_block\x18\x03 \x01(\x0cH\x00\x42\x0b\n\tresponses\"\'\n\x0fRawTransactions\x12\x14\n\x0ctransactions\x18\x01 \x03(\x0c\"+\n\x17InstantSendLockMessages\x12\x10\n\x08messages\x18\x01 \x03(\x0c\x32\xb6\x07\n\x04\x43ore\x12\x66\n\tgetStatus\x12+.org.dash.platform.dapi.v0.GetStatusRequest\x1a,.org.dash.platform.dapi.v0.GetStatusResponse\x12\x63\n\x08getBlock\x12*.org.dash.platform.dapi.v0.GetBlockRequest\x1a+.org.dash.platform.dapi.v0.GetBlockResponse\x12\x87\x01\n\x14\x62roadcastTransaction\x12\x36.org.dash.platform.dapi.v0.BroadcastTransactionRequest\x1a\x37.org.dash.platform.dapi.v0.BroadcastTransactionResponse\x12u\n\x0egetTransaction\x12\x30.org.dash.platform.dapi.v0.GetTransactionRequest\x1a\x31.org.dash.platform.dapi.v0.GetTransactionResponse\x12\x99\x01\n\x1agetEstimatedTransactionFee\x12<.org.dash.platform.dapi.v0.GetEstimatedTransactionFeeRequest\x1a=.org.dash.platform.dapi.v0.GetEstimatedTransactionFeeResponse\x12\xa6\x01\n%subscribeToBlockHeadersWithChainLocks\x12<.org.dash.platform.dapi.v0.BlockHeadersWithChainLocksRequest\x1a=.org.dash.platform.dapi.v0.BlockHeadersWithChainLocksResponse0\x01\x12\x9a\x01\n!subscribeToTransactionsWithProofs\x12\x38.org.dash.platform.dapi.v0.TransactionsWithProofsRequest\x1a\x39.org.dash.platform.dapi.v0.TransactionsWithProofsResponse0\x01\x62\x06proto3')
+  serialized_pb=_b('\n\ncore.proto\x12\x19org.dash.platform.dapi.v0\"\x12\n\x10GetStatusRequest\"\xa5\t\n\x11GetStatusResponse\x12\x45\n\x07version\x18\x01 \x01(\x0b\x32\x34.org.dash.platform.dapi.v0.GetStatusResponse.Version\x12?\n\x04time\x18\x02 \x01(\x0b\x32\x31.org.dash.platform.dapi.v0.GetStatusResponse.Time\x12\x43\n\x06status\x18\x03 \x01(\x0e\x32\x33.org.dash.platform.dapi.v0.GetStatusResponse.Status\x12\x15\n\rsync_progress\x18\x04 \x01(\x01\x12\x41\n\x05\x63hain\x18\x05 \x01(\x0b\x32\x32.org.dash.platform.dapi.v0.GetStatusResponse.Chain\x12\x45\n\x07network\x18\x06 \x01(\x0b\x32\x34.org.dash.platform.dapi.v0.GetStatusResponse.Network\x1a<\n\x07Version\x12\x10\n\x08protocol\x18\x01 \x01(\r\x12\x10\n\x08software\x18\x02 \x01(\r\x12\r\n\x05\x61gent\x18\x03 \x01(\t\x1a\x33\n\x04Time\x12\x0b\n\x03now\x18\x01 \x01(\r\x12\x0e\n\x06offset\x18\x02 \x01(\x05\x12\x0e\n\x06median\x18\x03 \x01(\r\x1a\xad\x01\n\x05\x43hain\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x15\n\rheaders_count\x18\x02 \x01(\r\x12\x14\n\x0c\x62locks_count\x18\x03 \x01(\r\x12\x17\n\x0f\x62\x65st_block_hash\x18\x04 \x01(\x0c\x12\x12\n\ndifficulty\x18\x05 \x01(\x01\x12\x12\n\nchain_work\x18\x06 \x01(\x0c\x12\x11\n\tis_synced\x18\x07 \x01(\x08\x12\x15\n\rsync_progress\x18\x08 \x01(\x01\x1a\xac\x02\n\nMasternode\x12\x0e\n\x06status\x18\x01 \x01(\t\x12\x13\n\x0bpro_tx_hash\x18\x02 \x01(\x0c\x12\x13\n\x0bposePenalty\x18\x03 \x01(\r\x12\x11\n\tis_synced\x18\x04 \x01(\x08\x12W\n\x0bsync_status\x18\x05 \x01(\x0e\x32\x42.org.dash.platform.dapi.v0.GetStatusResponse.Masternode.SyncStatus\"x\n\nSyncStatus\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x1e\n\x1aMASTERNODE_SYNC_BLOCKCHAIN\x10\x01\x12\x1e\n\x1aMASTERNODE_SYNC_GOVERNANCE\x10\x04\x12\x1d\n\x18MASTERNODE_SYNC_FINISHED\x10\xe7\x07\x1a\x8f\x01\n\x07Network\x12\x12\n\npeersCount\x18\x01 \x01(\r\x12\x45\n\x03\x66\x65\x65\x18\x02 \x01(\x0b\x32\x38.org.dash.platform.dapi.v0.GetStatusResponse.Network.Fee\x1a)\n\x03\x46\x65\x65\x12\r\n\x05relay\x18\x01 \x01(\x01\x12\x13\n\x0bincremental\x18\x02 \x01(\x01\">\n\x06Status\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x0f\n\x0bNOT_STARTED\x10\x01\x12\x0b\n\x07SYNCING\x10\x02\x12\t\n\x05READY\x10\x03\"<\n\x0fGetBlockRequest\x12\x10\n\x06height\x18\x01 \x01(\rH\x00\x12\x0e\n\x04hash\x18\x02 \x01(\tH\x00\x42\x07\n\x05\x62lock\"!\n\x10GetBlockResponse\x12\r\n\x05\x62lock\x18\x01 \x01(\x0c\"b\n\x1b\x42roadcastTransactionRequest\x12\x13\n\x0btransaction\x18\x01 \x01(\x0c\x12\x17\n\x0f\x61llow_high_fees\x18\x02 \x01(\x08\x12\x15\n\rbypass_limits\x18\x03 \x01(\x08\"6\n\x1c\x42roadcastTransactionResponse\x12\x16\n\x0etransaction_id\x18\x01 \x01(\t\"#\n\x15GetTransactionRequest\x12\n\n\x02id\x18\x01 \x01(\t\"-\n\x16GetTransactionResponse\x12\x13\n\x0btransaction\x18\x01 \x01(\x0c\"x\n!BlockHeadersWithChainLocksRequest\x12\x19\n\x0f\x66rom_block_hash\x18\x01 \x01(\x0cH\x00\x12\x1b\n\x11\x66rom_block_height\x18\x02 \x01(\rH\x00\x12\r\n\x05\x63ount\x18\x03 \x01(\rB\x0c\n\nfrom_block\"\xd3\x01\n\"BlockHeadersWithChainLocksResponse\x12@\n\rblock_headers\x18\x01 \x01(\x0b\x32\'.org.dash.platform.dapi.v0.BlockHeadersH\x00\x12^\n\x1d\x63hain_lock_signature_messages\x18\x02 \x01(\x0b\x32\x35.org.dash.platform.dapi.v0.ChainLockSignatureMessagesH\x00\x42\x0b\n\tresponses\"\x1f\n\x0c\x42lockHeaders\x12\x0f\n\x07headers\x18\x01 \x03(\x0c\".\n\x1a\x43hainLockSignatureMessages\x12\x10\n\x08messages\x18\x01 \x03(\x0c\"3\n!GetEstimatedTransactionFeeRequest\x12\x0e\n\x06\x62locks\x18\x01 \x01(\r\"1\n\"GetEstimatedTransactionFeeResponse\x12\x0b\n\x03\x66\x65\x65\x18\x01 \x01(\x01\"\xd3\x01\n\x1dTransactionsWithProofsRequest\x12<\n\x0c\x62loom_filter\x18\x01 \x01(\x0b\x32&.org.dash.platform.dapi.v0.BloomFilter\x12\x19\n\x0f\x66rom_block_hash\x18\x02 \x01(\x0cH\x00\x12\x1b\n\x11\x66rom_block_height\x18\x03 \x01(\rH\x00\x12\r\n\x05\x63ount\x18\x04 \x01(\r\x12\x1f\n\x17send_transaction_hashes\x18\x05 \x01(\x08\x42\x0c\n\nfrom_block\"U\n\x0b\x42loomFilter\x12\x0e\n\x06v_data\x18\x01 \x01(\x0c\x12\x14\n\x0cn_hash_funcs\x18\x02 \x01(\r\x12\x0f\n\x07n_tweak\x18\x03 \x01(\r\x12\x0f\n\x07n_flags\x18\x04 \x01(\r\"\xeb\x01\n\x1eTransactionsWithProofsResponse\x12\x46\n\x10raw_transactions\x18\x01 \x01(\x0b\x32*.org.dash.platform.dapi.v0.RawTransactionsH\x00\x12X\n\x1ainstant_send_lock_messages\x18\x02 \x01(\x0b\x32\x32.org.dash.platform.dapi.v0.InstantSendLockMessagesH\x00\x12\x1a\n\x10raw_merkle_block\x18\x03 \x01(\x0cH\x00\x42\x0b\n\tresponses\"\'\n\x0fRawTransactions\x12\x14\n\x0ctransactions\x18\x01 \x03(\x0c\"+\n\x17InstantSendLockMessages\x12\x10\n\x08messages\x18\x01 \x03(\x0c\x32\xb6\x07\n\x04\x43ore\x12\x66\n\tgetStatus\x12+.org.dash.platform.dapi.v0.GetStatusRequest\x1a,.org.dash.platform.dapi.v0.GetStatusResponse\x12\x63\n\x08getBlock\x12*.org.dash.platform.dapi.v0.GetBlockRequest\x1a+.org.dash.platform.dapi.v0.GetBlockResponse\x12\x87\x01\n\x14\x62roadcastTransaction\x12\x36.org.dash.platform.dapi.v0.BroadcastTransactionRequest\x1a\x37.org.dash.platform.dapi.v0.BroadcastTransactionResponse\x12u\n\x0egetTransaction\x12\x30.org.dash.platform.dapi.v0.GetTransactionRequest\x1a\x31.org.dash.platform.dapi.v0.GetTransactionResponse\x12\x99\x01\n\x1agetEstimatedTransactionFee\x12<.org.dash.platform.dapi.v0.GetEstimatedTransactionFeeRequest\x1a=.org.dash.platform.dapi.v0.GetEstimatedTransactionFeeResponse\x12\xa6\x01\n%subscribeToBlockHeadersWithChainLocks\x12<.org.dash.platform.dapi.v0.BlockHeadersWithChainLocksRequest\x1a=.org.dash.platform.dapi.v0.BlockHeadersWithChainLocksResponse0\x01\x12\x9a\x01\n!subscribeToTransactionsWithProofs\x12\x38.org.dash.platform.dapi.v0.TransactionsWithProofsRequest\x1a\x39.org.dash.platform.dapi.v0.TransactionsWithProofsResponse0\x01\x62\x06proto3')
 )
 
 
+
+_GETSTATUSRESPONSE_MASTERNODE_SYNCSTATUS = _descriptor.EnumDescriptor(
+  name='SyncStatus',
+  full_name='org.dash.platform.dapi.v0.GetStatusResponse.Masternode.SyncStatus',
+  filename=None,
+  file=DESCRIPTOR,
+  values=[
+    _descriptor.EnumValueDescriptor(
+      name='UNKNOWN', index=0, number=0,
+      options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='MASTERNODE_SYNC_BLOCKCHAIN', index=1, number=1,
+      options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='MASTERNODE_SYNC_GOVERNANCE', index=2, number=4,
+      options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='MASTERNODE_SYNC_FINISHED', index=3, number=999,
+      options=None,
+      type=None),
+  ],
+  containing_type=None,
+  options=None,
+  serialized_start=921,
+  serialized_end=1041,
+)
+_sym_db.RegisterEnumDescriptor(_GETSTATUSRESPONSE_MASTERNODE_SYNCSTATUS)
+
+_GETSTATUSRESPONSE_STATUS = _descriptor.EnumDescriptor(
+  name='Status',
+  full_name='org.dash.platform.dapi.v0.GetStatusResponse.Status',
+  filename=None,
+  file=DESCRIPTOR,
+  values=[
+    _descriptor.EnumValueDescriptor(
+      name='UNKNOWN', index=0, number=0,
+      options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='NOT_STARTED', index=1, number=1,
+      options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='SYNCING', index=2, number=2,
+      options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='READY', index=3, number=3,
+      options=None,
+      type=None),
+  ],
+  containing_type=None,
+  options=None,
+  serialized_start=1189,
+  serialized_end=1251,
+)
+_sym_db.RegisterEnumDescriptor(_GETSTATUSRESPONSE_STATUS)
 
 
 _GETSTATUSREQUEST = _descriptor.Descriptor(
@@ -49,86 +109,30 @@ _GETSTATUSREQUEST = _descriptor.Descriptor(
 )
 
 
-_GETSTATUSRESPONSE = _descriptor.Descriptor(
-  name='GetStatusResponse',
-  full_name='org.dash.platform.dapi.v0.GetStatusResponse',
+_GETSTATUSRESPONSE_VERSION = _descriptor.Descriptor(
+  name='Version',
+  full_name='org.dash.platform.dapi.v0.GetStatusResponse.Version',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='core_version', full_name='org.dash.platform.dapi.v0.GetStatusResponse.core_version', index=0,
+      name='protocol', full_name='org.dash.platform.dapi.v0.GetStatusResponse.Version.protocol', index=0,
       number=1, type=13, cpp_type=3, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='protocol_version', full_name='org.dash.platform.dapi.v0.GetStatusResponse.protocol_version', index=1,
+      name='software', full_name='org.dash.platform.dapi.v0.GetStatusResponse.Version.software', index=1,
       number=2, type=13, cpp_type=3, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='blocks', full_name='org.dash.platform.dapi.v0.GetStatusResponse.blocks', index=2,
-      number=3, type=13, cpp_type=3, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='time_offset', full_name='org.dash.platform.dapi.v0.GetStatusResponse.time_offset', index=3,
-      number=4, type=13, cpp_type=3, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='connections', full_name='org.dash.platform.dapi.v0.GetStatusResponse.connections', index=4,
-      number=5, type=13, cpp_type=3, label=1,
-      has_default_value=False, default_value=0,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='proxy', full_name='org.dash.platform.dapi.v0.GetStatusResponse.proxy', index=5,
-      number=6, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='difficulty', full_name='org.dash.platform.dapi.v0.GetStatusResponse.difficulty', index=6,
-      number=7, type=1, cpp_type=5, label=1,
-      has_default_value=False, default_value=float(0),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='testnet', full_name='org.dash.platform.dapi.v0.GetStatusResponse.testnet', index=7,
-      number=8, type=8, cpp_type=7, label=1,
-      has_default_value=False, default_value=False,
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='relay_fee', full_name='org.dash.platform.dapi.v0.GetStatusResponse.relay_fee', index=8,
-      number=9, type=1, cpp_type=5, label=1,
-      has_default_value=False, default_value=float(0),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='errors', full_name='org.dash.platform.dapi.v0.GetStatusResponse.errors', index=9,
-      number=10, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      options=None),
-    _descriptor.FieldDescriptor(
-      name='network', full_name='org.dash.platform.dapi.v0.GetStatusResponse.network', index=10,
-      number=11, type=9, cpp_type=9, label=1,
+      name='agent', full_name='org.dash.platform.dapi.v0.GetStatusResponse.Version.agent', index=2,
+      number=3, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
@@ -145,8 +149,330 @@ _GETSTATUSRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
+  serialized_start=449,
+  serialized_end=509,
+)
+
+_GETSTATUSRESPONSE_TIME = _descriptor.Descriptor(
+  name='Time',
+  full_name='org.dash.platform.dapi.v0.GetStatusResponse.Time',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='now', full_name='org.dash.platform.dapi.v0.GetStatusResponse.Time.now', index=0,
+      number=1, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='offset', full_name='org.dash.platform.dapi.v0.GetStatusResponse.Time.offset', index=1,
+      number=2, type=5, cpp_type=1, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='median', full_name='org.dash.platform.dapi.v0.GetStatusResponse.Time.median', index=2,
+      number=3, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=511,
+  serialized_end=562,
+)
+
+_GETSTATUSRESPONSE_CHAIN = _descriptor.Descriptor(
+  name='Chain',
+  full_name='org.dash.platform.dapi.v0.GetStatusResponse.Chain',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='name', full_name='org.dash.platform.dapi.v0.GetStatusResponse.Chain.name', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='headers_count', full_name='org.dash.platform.dapi.v0.GetStatusResponse.Chain.headers_count', index=1,
+      number=2, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='blocks_count', full_name='org.dash.platform.dapi.v0.GetStatusResponse.Chain.blocks_count', index=2,
+      number=3, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='best_block_hash', full_name='org.dash.platform.dapi.v0.GetStatusResponse.Chain.best_block_hash', index=3,
+      number=4, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b(""),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='difficulty', full_name='org.dash.platform.dapi.v0.GetStatusResponse.Chain.difficulty', index=4,
+      number=5, type=1, cpp_type=5, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='chain_work', full_name='org.dash.platform.dapi.v0.GetStatusResponse.Chain.chain_work', index=5,
+      number=6, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b(""),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='is_synced', full_name='org.dash.platform.dapi.v0.GetStatusResponse.Chain.is_synced', index=6,
+      number=7, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='sync_progress', full_name='org.dash.platform.dapi.v0.GetStatusResponse.Chain.sync_progress', index=7,
+      number=8, type=1, cpp_type=5, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=565,
+  serialized_end=738,
+)
+
+_GETSTATUSRESPONSE_MASTERNODE = _descriptor.Descriptor(
+  name='Masternode',
+  full_name='org.dash.platform.dapi.v0.GetStatusResponse.Masternode',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='status', full_name='org.dash.platform.dapi.v0.GetStatusResponse.Masternode.status', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='pro_tx_hash', full_name='org.dash.platform.dapi.v0.GetStatusResponse.Masternode.pro_tx_hash', index=1,
+      number=2, type=12, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b(""),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='posePenalty', full_name='org.dash.platform.dapi.v0.GetStatusResponse.Masternode.posePenalty', index=2,
+      number=3, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='is_synced', full_name='org.dash.platform.dapi.v0.GetStatusResponse.Masternode.is_synced', index=3,
+      number=4, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='sync_status', full_name='org.dash.platform.dapi.v0.GetStatusResponse.Masternode.sync_status', index=4,
+      number=5, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+    _GETSTATUSRESPONSE_MASTERNODE_SYNCSTATUS,
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=741,
+  serialized_end=1041,
+)
+
+_GETSTATUSRESPONSE_NETWORK_FEE = _descriptor.Descriptor(
+  name='Fee',
+  full_name='org.dash.platform.dapi.v0.GetStatusResponse.Network.Fee',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='relay', full_name='org.dash.platform.dapi.v0.GetStatusResponse.Network.Fee.relay', index=0,
+      number=1, type=1, cpp_type=5, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='incremental', full_name='org.dash.platform.dapi.v0.GetStatusResponse.Network.Fee.incremental', index=1,
+      number=2, type=1, cpp_type=5, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=1146,
+  serialized_end=1187,
+)
+
+_GETSTATUSRESPONSE_NETWORK = _descriptor.Descriptor(
+  name='Network',
+  full_name='org.dash.platform.dapi.v0.GetStatusResponse.Network',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='peersCount', full_name='org.dash.platform.dapi.v0.GetStatusResponse.Network.peersCount', index=0,
+      number=1, type=13, cpp_type=3, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='fee', full_name='org.dash.platform.dapi.v0.GetStatusResponse.Network.fee', index=1,
+      number=2, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+  ],
+  extensions=[
+  ],
+  nested_types=[_GETSTATUSRESPONSE_NETWORK_FEE, ],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=1044,
+  serialized_end=1187,
+)
+
+_GETSTATUSRESPONSE = _descriptor.Descriptor(
+  name='GetStatusResponse',
+  full_name='org.dash.platform.dapi.v0.GetStatusResponse',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='version', full_name='org.dash.platform.dapi.v0.GetStatusResponse.version', index=0,
+      number=1, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='time', full_name='org.dash.platform.dapi.v0.GetStatusResponse.time', index=1,
+      number=2, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='status', full_name='org.dash.platform.dapi.v0.GetStatusResponse.status', index=2,
+      number=3, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='sync_progress', full_name='org.dash.platform.dapi.v0.GetStatusResponse.sync_progress', index=3,
+      number=4, type=1, cpp_type=5, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='chain', full_name='org.dash.platform.dapi.v0.GetStatusResponse.chain', index=4,
+      number=5, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='network', full_name='org.dash.platform.dapi.v0.GetStatusResponse.network', index=5,
+      number=6, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+  ],
+  extensions=[
+  ],
+  nested_types=[_GETSTATUSRESPONSE_VERSION, _GETSTATUSRESPONSE_TIME, _GETSTATUSRESPONSE_CHAIN, _GETSTATUSRESPONSE_MASTERNODE, _GETSTATUSRESPONSE_NETWORK, ],
+  enum_types=[
+    _GETSTATUSRESPONSE_STATUS,
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
   serialized_start=62,
-  serialized_end=291,
+  serialized_end=1251,
 )
 
 
@@ -186,8 +512,8 @@ _GETBLOCKREQUEST = _descriptor.Descriptor(
       name='block', full_name='org.dash.platform.dapi.v0.GetBlockRequest.block',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=293,
-  serialized_end=353,
+  serialized_start=1253,
+  serialized_end=1313,
 )
 
 
@@ -217,8 +543,8 @@ _GETBLOCKRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=355,
-  serialized_end=388,
+  serialized_start=1315,
+  serialized_end=1348,
 )
 
 
@@ -262,8 +588,8 @@ _BROADCASTTRANSACTIONREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=390,
-  serialized_end=488,
+  serialized_start=1350,
+  serialized_end=1448,
 )
 
 
@@ -293,8 +619,8 @@ _BROADCASTTRANSACTIONRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=490,
-  serialized_end=544,
+  serialized_start=1450,
+  serialized_end=1504,
 )
 
 
@@ -324,8 +650,8 @@ _GETTRANSACTIONREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=546,
-  serialized_end=581,
+  serialized_start=1506,
+  serialized_end=1541,
 )
 
 
@@ -355,8 +681,8 @@ _GETTRANSACTIONRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=583,
-  serialized_end=628,
+  serialized_start=1543,
+  serialized_end=1588,
 )
 
 
@@ -403,8 +729,8 @@ _BLOCKHEADERSWITHCHAINLOCKSREQUEST = _descriptor.Descriptor(
       name='from_block', full_name='org.dash.platform.dapi.v0.BlockHeadersWithChainLocksRequest.from_block',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=630,
-  serialized_end=750,
+  serialized_start=1590,
+  serialized_end=1710,
 )
 
 
@@ -444,8 +770,8 @@ _BLOCKHEADERSWITHCHAINLOCKSRESPONSE = _descriptor.Descriptor(
       name='responses', full_name='org.dash.platform.dapi.v0.BlockHeadersWithChainLocksResponse.responses',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=753,
-  serialized_end=964,
+  serialized_start=1713,
+  serialized_end=1924,
 )
 
 
@@ -475,8 +801,8 @@ _BLOCKHEADERS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=966,
-  serialized_end=997,
+  serialized_start=1926,
+  serialized_end=1957,
 )
 
 
@@ -506,8 +832,8 @@ _CHAINLOCKSIGNATUREMESSAGES = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=999,
-  serialized_end=1045,
+  serialized_start=1959,
+  serialized_end=2005,
 )
 
 
@@ -537,8 +863,8 @@ _GETESTIMATEDTRANSACTIONFEEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1047,
-  serialized_end=1098,
+  serialized_start=2007,
+  serialized_end=2058,
 )
 
 
@@ -568,8 +894,8 @@ _GETESTIMATEDTRANSACTIONFEERESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1100,
-  serialized_end=1149,
+  serialized_start=2060,
+  serialized_end=2109,
 )
 
 
@@ -630,8 +956,8 @@ _TRANSACTIONSWITHPROOFSREQUEST = _descriptor.Descriptor(
       name='from_block', full_name='org.dash.platform.dapi.v0.TransactionsWithProofsRequest.from_block',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=1152,
-  serialized_end=1363,
+  serialized_start=2112,
+  serialized_end=2323,
 )
 
 
@@ -682,8 +1008,8 @@ _BLOOMFILTER = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1365,
-  serialized_end=1450,
+  serialized_start=2325,
+  serialized_end=2410,
 )
 
 
@@ -730,8 +1056,8 @@ _TRANSACTIONSWITHPROOFSRESPONSE = _descriptor.Descriptor(
       name='responses', full_name='org.dash.platform.dapi.v0.TransactionsWithProofsResponse.responses',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=1453,
-  serialized_end=1688,
+  serialized_start=2413,
+  serialized_end=2648,
 )
 
 
@@ -761,8 +1087,8 @@ _RAWTRANSACTIONS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1690,
-  serialized_end=1729,
+  serialized_start=2650,
+  serialized_end=2689,
 )
 
 
@@ -792,10 +1118,25 @@ _INSTANTSENDLOCKMESSAGES = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1731,
-  serialized_end=1774,
+  serialized_start=2691,
+  serialized_end=2734,
 )
 
+_GETSTATUSRESPONSE_VERSION.containing_type = _GETSTATUSRESPONSE
+_GETSTATUSRESPONSE_TIME.containing_type = _GETSTATUSRESPONSE
+_GETSTATUSRESPONSE_CHAIN.containing_type = _GETSTATUSRESPONSE
+_GETSTATUSRESPONSE_MASTERNODE.fields_by_name['sync_status'].enum_type = _GETSTATUSRESPONSE_MASTERNODE_SYNCSTATUS
+_GETSTATUSRESPONSE_MASTERNODE.containing_type = _GETSTATUSRESPONSE
+_GETSTATUSRESPONSE_MASTERNODE_SYNCSTATUS.containing_type = _GETSTATUSRESPONSE_MASTERNODE
+_GETSTATUSRESPONSE_NETWORK_FEE.containing_type = _GETSTATUSRESPONSE_NETWORK
+_GETSTATUSRESPONSE_NETWORK.fields_by_name['fee'].message_type = _GETSTATUSRESPONSE_NETWORK_FEE
+_GETSTATUSRESPONSE_NETWORK.containing_type = _GETSTATUSRESPONSE
+_GETSTATUSRESPONSE.fields_by_name['version'].message_type = _GETSTATUSRESPONSE_VERSION
+_GETSTATUSRESPONSE.fields_by_name['time'].message_type = _GETSTATUSRESPONSE_TIME
+_GETSTATUSRESPONSE.fields_by_name['status'].enum_type = _GETSTATUSRESPONSE_STATUS
+_GETSTATUSRESPONSE.fields_by_name['chain'].message_type = _GETSTATUSRESPONSE_CHAIN
+_GETSTATUSRESPONSE.fields_by_name['network'].message_type = _GETSTATUSRESPONSE_NETWORK
+_GETSTATUSRESPONSE_STATUS.containing_type = _GETSTATUSRESPONSE
 _GETBLOCKREQUEST.oneofs_by_name['block'].fields.append(
   _GETBLOCKREQUEST.fields_by_name['height'])
 _GETBLOCKREQUEST.fields_by_name['height'].containing_oneof = _GETBLOCKREQUEST.oneofs_by_name['block']
@@ -863,11 +1204,59 @@ GetStatusRequest = _reflection.GeneratedProtocolMessageType('GetStatusRequest', 
 _sym_db.RegisterMessage(GetStatusRequest)
 
 GetStatusResponse = _reflection.GeneratedProtocolMessageType('GetStatusResponse', (_message.Message,), dict(
+
+  Version = _reflection.GeneratedProtocolMessageType('Version', (_message.Message,), dict(
+    DESCRIPTOR = _GETSTATUSRESPONSE_VERSION,
+    __module__ = 'core_pb2'
+    # @@protoc_insertion_point(class_scope:org.dash.platform.dapi.v0.GetStatusResponse.Version)
+    ))
+  ,
+
+  Time = _reflection.GeneratedProtocolMessageType('Time', (_message.Message,), dict(
+    DESCRIPTOR = _GETSTATUSRESPONSE_TIME,
+    __module__ = 'core_pb2'
+    # @@protoc_insertion_point(class_scope:org.dash.platform.dapi.v0.GetStatusResponse.Time)
+    ))
+  ,
+
+  Chain = _reflection.GeneratedProtocolMessageType('Chain', (_message.Message,), dict(
+    DESCRIPTOR = _GETSTATUSRESPONSE_CHAIN,
+    __module__ = 'core_pb2'
+    # @@protoc_insertion_point(class_scope:org.dash.platform.dapi.v0.GetStatusResponse.Chain)
+    ))
+  ,
+
+  Masternode = _reflection.GeneratedProtocolMessageType('Masternode', (_message.Message,), dict(
+    DESCRIPTOR = _GETSTATUSRESPONSE_MASTERNODE,
+    __module__ = 'core_pb2'
+    # @@protoc_insertion_point(class_scope:org.dash.platform.dapi.v0.GetStatusResponse.Masternode)
+    ))
+  ,
+
+  Network = _reflection.GeneratedProtocolMessageType('Network', (_message.Message,), dict(
+
+    Fee = _reflection.GeneratedProtocolMessageType('Fee', (_message.Message,), dict(
+      DESCRIPTOR = _GETSTATUSRESPONSE_NETWORK_FEE,
+      __module__ = 'core_pb2'
+      # @@protoc_insertion_point(class_scope:org.dash.platform.dapi.v0.GetStatusResponse.Network.Fee)
+      ))
+    ,
+    DESCRIPTOR = _GETSTATUSRESPONSE_NETWORK,
+    __module__ = 'core_pb2'
+    # @@protoc_insertion_point(class_scope:org.dash.platform.dapi.v0.GetStatusResponse.Network)
+    ))
+  ,
   DESCRIPTOR = _GETSTATUSRESPONSE,
   __module__ = 'core_pb2'
   # @@protoc_insertion_point(class_scope:org.dash.platform.dapi.v0.GetStatusResponse)
   ))
 _sym_db.RegisterMessage(GetStatusResponse)
+_sym_db.RegisterMessage(GetStatusResponse.Version)
+_sym_db.RegisterMessage(GetStatusResponse.Time)
+_sym_db.RegisterMessage(GetStatusResponse.Chain)
+_sym_db.RegisterMessage(GetStatusResponse.Masternode)
+_sym_db.RegisterMessage(GetStatusResponse.Network)
+_sym_db.RegisterMessage(GetStatusResponse.Network.Fee)
 
 GetBlockRequest = _reflection.GeneratedProtocolMessageType('GetBlockRequest', (_message.Message,), dict(
   DESCRIPTOR = _GETBLOCKREQUEST,
@@ -996,8 +1385,8 @@ _CORE = _descriptor.ServiceDescriptor(
   file=DESCRIPTOR,
   index=0,
   options=None,
-  serialized_start=1777,
-  serialized_end=2727,
+  serialized_start=2737,
+  serialized_end=3687,
   methods=[
   _descriptor.MethodDescriptor(
     name='getStatus',

--- a/clients/core/v0/python/core_pb2.py
+++ b/clients/core/v0/python/core_pb2.py
@@ -19,14 +19,14 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='core.proto',
   package='org.dash.platform.dapi.v0',
   syntax='proto3',
-  serialized_pb=_b('\n\ncore.proto\x12\x19org.dash.platform.dapi.v0\"\x12\n\x10GetStatusRequest\"\xa5\t\n\x11GetStatusResponse\x12\x45\n\x07version\x18\x01 \x01(\x0b\x32\x34.org.dash.platform.dapi.v0.GetStatusResponse.Version\x12?\n\x04time\x18\x02 \x01(\x0b\x32\x31.org.dash.platform.dapi.v0.GetStatusResponse.Time\x12\x43\n\x06status\x18\x03 \x01(\x0e\x32\x33.org.dash.platform.dapi.v0.GetStatusResponse.Status\x12\x15\n\rsync_progress\x18\x04 \x01(\x01\x12\x41\n\x05\x63hain\x18\x05 \x01(\x0b\x32\x32.org.dash.platform.dapi.v0.GetStatusResponse.Chain\x12\x45\n\x07network\x18\x06 \x01(\x0b\x32\x34.org.dash.platform.dapi.v0.GetStatusResponse.Network\x1a<\n\x07Version\x12\x10\n\x08protocol\x18\x01 \x01(\r\x12\x10\n\x08software\x18\x02 \x01(\r\x12\r\n\x05\x61gent\x18\x03 \x01(\t\x1a\x33\n\x04Time\x12\x0b\n\x03now\x18\x01 \x01(\r\x12\x0e\n\x06offset\x18\x02 \x01(\x05\x12\x0e\n\x06median\x18\x03 \x01(\r\x1a\xad\x01\n\x05\x43hain\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x15\n\rheaders_count\x18\x02 \x01(\r\x12\x14\n\x0c\x62locks_count\x18\x03 \x01(\r\x12\x17\n\x0f\x62\x65st_block_hash\x18\x04 \x01(\x0c\x12\x12\n\ndifficulty\x18\x05 \x01(\x01\x12\x12\n\nchain_work\x18\x06 \x01(\x0c\x12\x11\n\tis_synced\x18\x07 \x01(\x08\x12\x15\n\rsync_progress\x18\x08 \x01(\x01\x1a\xac\x02\n\nMasternode\x12\x0e\n\x06status\x18\x01 \x01(\t\x12\x13\n\x0bpro_tx_hash\x18\x02 \x01(\x0c\x12\x13\n\x0bposePenalty\x18\x03 \x01(\r\x12\x11\n\tis_synced\x18\x04 \x01(\x08\x12W\n\x0bsync_status\x18\x05 \x01(\x0e\x32\x42.org.dash.platform.dapi.v0.GetStatusResponse.Masternode.SyncStatus\"x\n\nSyncStatus\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x1e\n\x1aMASTERNODE_SYNC_BLOCKCHAIN\x10\x01\x12\x1e\n\x1aMASTERNODE_SYNC_GOVERNANCE\x10\x04\x12\x1d\n\x18MASTERNODE_SYNC_FINISHED\x10\xe7\x07\x1a\x8f\x01\n\x07Network\x12\x12\n\npeersCount\x18\x01 \x01(\r\x12\x45\n\x03\x66\x65\x65\x18\x02 \x01(\x0b\x32\x38.org.dash.platform.dapi.v0.GetStatusResponse.Network.Fee\x1a)\n\x03\x46\x65\x65\x12\r\n\x05relay\x18\x01 \x01(\x01\x12\x13\n\x0bincremental\x18\x02 \x01(\x01\">\n\x06Status\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x0f\n\x0bNOT_STARTED\x10\x01\x12\x0b\n\x07SYNCING\x10\x02\x12\t\n\x05READY\x10\x03\"<\n\x0fGetBlockRequest\x12\x10\n\x06height\x18\x01 \x01(\rH\x00\x12\x0e\n\x04hash\x18\x02 \x01(\tH\x00\x42\x07\n\x05\x62lock\"!\n\x10GetBlockResponse\x12\r\n\x05\x62lock\x18\x01 \x01(\x0c\"b\n\x1b\x42roadcastTransactionRequest\x12\x13\n\x0btransaction\x18\x01 \x01(\x0c\x12\x17\n\x0f\x61llow_high_fees\x18\x02 \x01(\x08\x12\x15\n\rbypass_limits\x18\x03 \x01(\x08\"6\n\x1c\x42roadcastTransactionResponse\x12\x16\n\x0etransaction_id\x18\x01 \x01(\t\"#\n\x15GetTransactionRequest\x12\n\n\x02id\x18\x01 \x01(\t\"-\n\x16GetTransactionResponse\x12\x13\n\x0btransaction\x18\x01 \x01(\x0c\"x\n!BlockHeadersWithChainLocksRequest\x12\x19\n\x0f\x66rom_block_hash\x18\x01 \x01(\x0cH\x00\x12\x1b\n\x11\x66rom_block_height\x18\x02 \x01(\rH\x00\x12\r\n\x05\x63ount\x18\x03 \x01(\rB\x0c\n\nfrom_block\"\xd3\x01\n\"BlockHeadersWithChainLocksResponse\x12@\n\rblock_headers\x18\x01 \x01(\x0b\x32\'.org.dash.platform.dapi.v0.BlockHeadersH\x00\x12^\n\x1d\x63hain_lock_signature_messages\x18\x02 \x01(\x0b\x32\x35.org.dash.platform.dapi.v0.ChainLockSignatureMessagesH\x00\x42\x0b\n\tresponses\"\x1f\n\x0c\x42lockHeaders\x12\x0f\n\x07headers\x18\x01 \x03(\x0c\".\n\x1a\x43hainLockSignatureMessages\x12\x10\n\x08messages\x18\x01 \x03(\x0c\"3\n!GetEstimatedTransactionFeeRequest\x12\x0e\n\x06\x62locks\x18\x01 \x01(\r\"1\n\"GetEstimatedTransactionFeeResponse\x12\x0b\n\x03\x66\x65\x65\x18\x01 \x01(\x01\"\xd3\x01\n\x1dTransactionsWithProofsRequest\x12<\n\x0c\x62loom_filter\x18\x01 \x01(\x0b\x32&.org.dash.platform.dapi.v0.BloomFilter\x12\x19\n\x0f\x66rom_block_hash\x18\x02 \x01(\x0cH\x00\x12\x1b\n\x11\x66rom_block_height\x18\x03 \x01(\rH\x00\x12\r\n\x05\x63ount\x18\x04 \x01(\r\x12\x1f\n\x17send_transaction_hashes\x18\x05 \x01(\x08\x42\x0c\n\nfrom_block\"U\n\x0b\x42loomFilter\x12\x0e\n\x06v_data\x18\x01 \x01(\x0c\x12\x14\n\x0cn_hash_funcs\x18\x02 \x01(\r\x12\x0f\n\x07n_tweak\x18\x03 \x01(\r\x12\x0f\n\x07n_flags\x18\x04 \x01(\r\"\xeb\x01\n\x1eTransactionsWithProofsResponse\x12\x46\n\x10raw_transactions\x18\x01 \x01(\x0b\x32*.org.dash.platform.dapi.v0.RawTransactionsH\x00\x12X\n\x1ainstant_send_lock_messages\x18\x02 \x01(\x0b\x32\x32.org.dash.platform.dapi.v0.InstantSendLockMessagesH\x00\x12\x1a\n\x10raw_merkle_block\x18\x03 \x01(\x0cH\x00\x42\x0b\n\tresponses\"\'\n\x0fRawTransactions\x12\x14\n\x0ctransactions\x18\x01 \x03(\x0c\"+\n\x17InstantSendLockMessages\x12\x10\n\x08messages\x18\x01 \x03(\x0c\x32\xb6\x07\n\x04\x43ore\x12\x66\n\tgetStatus\x12+.org.dash.platform.dapi.v0.GetStatusRequest\x1a,.org.dash.platform.dapi.v0.GetStatusResponse\x12\x63\n\x08getBlock\x12*.org.dash.platform.dapi.v0.GetBlockRequest\x1a+.org.dash.platform.dapi.v0.GetBlockResponse\x12\x87\x01\n\x14\x62roadcastTransaction\x12\x36.org.dash.platform.dapi.v0.BroadcastTransactionRequest\x1a\x37.org.dash.platform.dapi.v0.BroadcastTransactionResponse\x12u\n\x0egetTransaction\x12\x30.org.dash.platform.dapi.v0.GetTransactionRequest\x1a\x31.org.dash.platform.dapi.v0.GetTransactionResponse\x12\x99\x01\n\x1agetEstimatedTransactionFee\x12<.org.dash.platform.dapi.v0.GetEstimatedTransactionFeeRequest\x1a=.org.dash.platform.dapi.v0.GetEstimatedTransactionFeeResponse\x12\xa6\x01\n%subscribeToBlockHeadersWithChainLocks\x12<.org.dash.platform.dapi.v0.BlockHeadersWithChainLocksRequest\x1a=.org.dash.platform.dapi.v0.BlockHeadersWithChainLocksResponse0\x01\x12\x9a\x01\n!subscribeToTransactionsWithProofs\x12\x38.org.dash.platform.dapi.v0.TransactionsWithProofsRequest\x1a\x39.org.dash.platform.dapi.v0.TransactionsWithProofsResponse0\x01\x62\x06proto3')
+  serialized_pb=_b('\n\ncore.proto\x12\x19org.dash.platform.dapi.v0\"\x12\n\x10GetStatusRequest\"\xba\t\n\x11GetStatusResponse\x12\x45\n\x07version\x18\x01 \x01(\x0b\x32\x34.org.dash.platform.dapi.v0.GetStatusResponse.Version\x12?\n\x04time\x18\x02 \x01(\x0b\x32\x31.org.dash.platform.dapi.v0.GetStatusResponse.Time\x12\x43\n\x06status\x18\x03 \x01(\x0e\x32\x33.org.dash.platform.dapi.v0.GetStatusResponse.Status\x12\x15\n\rsync_progress\x18\x04 \x01(\x01\x12\x41\n\x05\x63hain\x18\x05 \x01(\x0b\x32\x32.org.dash.platform.dapi.v0.GetStatusResponse.Chain\x12\x45\n\x07network\x18\x06 \x01(\x0b\x32\x34.org.dash.platform.dapi.v0.GetStatusResponse.Network\x1a<\n\x07Version\x12\x10\n\x08protocol\x18\x01 \x01(\r\x12\x10\n\x08software\x18\x02 \x01(\r\x12\r\n\x05\x61gent\x18\x03 \x01(\t\x1a\x33\n\x04Time\x12\x0b\n\x03now\x18\x01 \x01(\r\x12\x0e\n\x06offset\x18\x02 \x01(\x05\x12\x0e\n\x06median\x18\x03 \x01(\r\x1a\xad\x01\n\x05\x43hain\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x15\n\rheaders_count\x18\x02 \x01(\r\x12\x14\n\x0c\x62locks_count\x18\x03 \x01(\r\x12\x17\n\x0f\x62\x65st_block_hash\x18\x04 \x01(\x0c\x12\x12\n\ndifficulty\x18\x05 \x01(\x01\x12\x12\n\nchain_work\x18\x06 \x01(\x0c\x12\x11\n\tis_synced\x18\x07 \x01(\x08\x12\x15\n\rsync_progress\x18\x08 \x01(\x01\x1a\xc3\x02\n\nMasternode\x12N\n\x06status\x18\x01 \x01(\x0e\x32>.org.dash.platform.dapi.v0.GetStatusResponse.Masternode.Status\x12\x13\n\x0bpro_tx_hash\x18\x02 \x01(\x0c\x12\x13\n\x0bposePenalty\x18\x03 \x01(\r\x12\x11\n\tis_synced\x18\x04 \x01(\x08\x12\x15\n\rsync_progress\x18\x05 \x01(\x01\"\x90\x01\n\x06Status\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x15\n\x11WAITING_FOR_PROTX\x10\x01\x12\x0f\n\x0bPOSE_BANNED\x10\x02\x12\x0b\n\x07REMOVED\x10\x03\x12\x18\n\x14OPERATOR_KEY_CHANGED\x10\x04\x12\x14\n\x10PROTX_IP_CHANGED\x10\x05\x12\t\n\x05READY\x10\x06\x12\t\n\x05\x45RROR\x10\x07\x1a\x8f\x01\n\x07Network\x12\x12\n\npeersCount\x18\x01 \x01(\r\x12\x45\n\x03\x66\x65\x65\x18\x02 \x01(\x0b\x32\x38.org.dash.platform.dapi.v0.GetStatusResponse.Network.Fee\x1a)\n\x03\x46\x65\x65\x12\r\n\x05relay\x18\x01 \x01(\x01\x12\x13\n\x0bincremental\x18\x02 \x01(\x01\"<\n\x06Status\x12\x0f\n\x0bNOT_STARTED\x10\x00\x12\x0b\n\x07SYNCING\x10\x01\x12\t\n\x05READY\x10\x02\x12\t\n\x05\x45RROR\x10\x03\"<\n\x0fGetBlockRequest\x12\x10\n\x06height\x18\x01 \x01(\rH\x00\x12\x0e\n\x04hash\x18\x02 \x01(\tH\x00\x42\x07\n\x05\x62lock\"!\n\x10GetBlockResponse\x12\r\n\x05\x62lock\x18\x01 \x01(\x0c\"b\n\x1b\x42roadcastTransactionRequest\x12\x13\n\x0btransaction\x18\x01 \x01(\x0c\x12\x17\n\x0f\x61llow_high_fees\x18\x02 \x01(\x08\x12\x15\n\rbypass_limits\x18\x03 \x01(\x08\"6\n\x1c\x42roadcastTransactionResponse\x12\x16\n\x0etransaction_id\x18\x01 \x01(\t\"#\n\x15GetTransactionRequest\x12\n\n\x02id\x18\x01 \x01(\t\"-\n\x16GetTransactionResponse\x12\x13\n\x0btransaction\x18\x01 \x01(\x0c\"x\n!BlockHeadersWithChainLocksRequest\x12\x19\n\x0f\x66rom_block_hash\x18\x01 \x01(\x0cH\x00\x12\x1b\n\x11\x66rom_block_height\x18\x02 \x01(\rH\x00\x12\r\n\x05\x63ount\x18\x03 \x01(\rB\x0c\n\nfrom_block\"\xd3\x01\n\"BlockHeadersWithChainLocksResponse\x12@\n\rblock_headers\x18\x01 \x01(\x0b\x32\'.org.dash.platform.dapi.v0.BlockHeadersH\x00\x12^\n\x1d\x63hain_lock_signature_messages\x18\x02 \x01(\x0b\x32\x35.org.dash.platform.dapi.v0.ChainLockSignatureMessagesH\x00\x42\x0b\n\tresponses\"\x1f\n\x0c\x42lockHeaders\x12\x0f\n\x07headers\x18\x01 \x03(\x0c\".\n\x1a\x43hainLockSignatureMessages\x12\x10\n\x08messages\x18\x01 \x03(\x0c\"3\n!GetEstimatedTransactionFeeRequest\x12\x0e\n\x06\x62locks\x18\x01 \x01(\r\"1\n\"GetEstimatedTransactionFeeResponse\x12\x0b\n\x03\x66\x65\x65\x18\x01 \x01(\x01\"\xd3\x01\n\x1dTransactionsWithProofsRequest\x12<\n\x0c\x62loom_filter\x18\x01 \x01(\x0b\x32&.org.dash.platform.dapi.v0.BloomFilter\x12\x19\n\x0f\x66rom_block_hash\x18\x02 \x01(\x0cH\x00\x12\x1b\n\x11\x66rom_block_height\x18\x03 \x01(\rH\x00\x12\r\n\x05\x63ount\x18\x04 \x01(\r\x12\x1f\n\x17send_transaction_hashes\x18\x05 \x01(\x08\x42\x0c\n\nfrom_block\"U\n\x0b\x42loomFilter\x12\x0e\n\x06v_data\x18\x01 \x01(\x0c\x12\x14\n\x0cn_hash_funcs\x18\x02 \x01(\r\x12\x0f\n\x07n_tweak\x18\x03 \x01(\r\x12\x0f\n\x07n_flags\x18\x04 \x01(\r\"\xeb\x01\n\x1eTransactionsWithProofsResponse\x12\x46\n\x10raw_transactions\x18\x01 \x01(\x0b\x32*.org.dash.platform.dapi.v0.RawTransactionsH\x00\x12X\n\x1ainstant_send_lock_messages\x18\x02 \x01(\x0b\x32\x32.org.dash.platform.dapi.v0.InstantSendLockMessagesH\x00\x12\x1a\n\x10raw_merkle_block\x18\x03 \x01(\x0cH\x00\x42\x0b\n\tresponses\"\'\n\x0fRawTransactions\x12\x14\n\x0ctransactions\x18\x01 \x03(\x0c\"+\n\x17InstantSendLockMessages\x12\x10\n\x08messages\x18\x01 \x03(\x0c\x32\xb6\x07\n\x04\x43ore\x12\x66\n\tgetStatus\x12+.org.dash.platform.dapi.v0.GetStatusRequest\x1a,.org.dash.platform.dapi.v0.GetStatusResponse\x12\x63\n\x08getBlock\x12*.org.dash.platform.dapi.v0.GetBlockRequest\x1a+.org.dash.platform.dapi.v0.GetBlockResponse\x12\x87\x01\n\x14\x62roadcastTransaction\x12\x36.org.dash.platform.dapi.v0.BroadcastTransactionRequest\x1a\x37.org.dash.platform.dapi.v0.BroadcastTransactionResponse\x12u\n\x0egetTransaction\x12\x30.org.dash.platform.dapi.v0.GetTransactionRequest\x1a\x31.org.dash.platform.dapi.v0.GetTransactionResponse\x12\x99\x01\n\x1agetEstimatedTransactionFee\x12<.org.dash.platform.dapi.v0.GetEstimatedTransactionFeeRequest\x1a=.org.dash.platform.dapi.v0.GetEstimatedTransactionFeeResponse\x12\xa6\x01\n%subscribeToBlockHeadersWithChainLocks\x12<.org.dash.platform.dapi.v0.BlockHeadersWithChainLocksRequest\x1a=.org.dash.platform.dapi.v0.BlockHeadersWithChainLocksResponse0\x01\x12\x9a\x01\n!subscribeToTransactionsWithProofs\x12\x38.org.dash.platform.dapi.v0.TransactionsWithProofsRequest\x1a\x39.org.dash.platform.dapi.v0.TransactionsWithProofsResponse0\x01\x62\x06proto3')
 )
 
 
 
-_GETSTATUSRESPONSE_MASTERNODE_SYNCSTATUS = _descriptor.EnumDescriptor(
-  name='SyncStatus',
-  full_name='org.dash.platform.dapi.v0.GetStatusResponse.Masternode.SyncStatus',
+_GETSTATUSRESPONSE_MASTERNODE_STATUS = _descriptor.EnumDescriptor(
+  name='Status',
+  full_name='org.dash.platform.dapi.v0.GetStatusResponse.Masternode.Status',
   filename=None,
   file=DESCRIPTOR,
   values=[
@@ -35,24 +35,40 @@ _GETSTATUSRESPONSE_MASTERNODE_SYNCSTATUS = _descriptor.EnumDescriptor(
       options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
-      name='MASTERNODE_SYNC_BLOCKCHAIN', index=1, number=1,
+      name='WAITING_FOR_PROTX', index=1, number=1,
       options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
-      name='MASTERNODE_SYNC_GOVERNANCE', index=2, number=4,
+      name='POSE_BANNED', index=2, number=2,
       options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
-      name='MASTERNODE_SYNC_FINISHED', index=3, number=999,
+      name='REMOVED', index=3, number=3,
+      options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='OPERATOR_KEY_CHANGED', index=4, number=4,
+      options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='PROTX_IP_CHANGED', index=5, number=5,
+      options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='READY', index=6, number=6,
+      options=None,
+      type=None),
+    _descriptor.EnumValueDescriptor(
+      name='ERROR', index=7, number=7,
       options=None,
       type=None),
   ],
   containing_type=None,
   options=None,
-  serialized_start=921,
-  serialized_end=1041,
+  serialized_start=920,
+  serialized_end=1064,
 )
-_sym_db.RegisterEnumDescriptor(_GETSTATUSRESPONSE_MASTERNODE_SYNCSTATUS)
+_sym_db.RegisterEnumDescriptor(_GETSTATUSRESPONSE_MASTERNODE_STATUS)
 
 _GETSTATUSRESPONSE_STATUS = _descriptor.EnumDescriptor(
   name='Status',
@@ -61,26 +77,26 @@ _GETSTATUSRESPONSE_STATUS = _descriptor.EnumDescriptor(
   file=DESCRIPTOR,
   values=[
     _descriptor.EnumValueDescriptor(
-      name='UNKNOWN', index=0, number=0,
+      name='NOT_STARTED', index=0, number=0,
       options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
-      name='NOT_STARTED', index=1, number=1,
+      name='SYNCING', index=1, number=1,
       options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
-      name='SYNCING', index=2, number=2,
+      name='READY', index=2, number=2,
       options=None,
       type=None),
     _descriptor.EnumValueDescriptor(
-      name='READY', index=3, number=3,
+      name='ERROR', index=3, number=3,
       options=None,
       type=None),
   ],
   containing_type=None,
   options=None,
-  serialized_start=1189,
-  serialized_end=1251,
+  serialized_start=1212,
+  serialized_end=1272,
 )
 _sym_db.RegisterEnumDescriptor(_GETSTATUSRESPONSE_STATUS)
 
@@ -285,8 +301,8 @@ _GETSTATUSRESPONSE_MASTERNODE = _descriptor.Descriptor(
   fields=[
     _descriptor.FieldDescriptor(
       name='status', full_name='org.dash.platform.dapi.v0.GetStatusResponse.Masternode.status', index=0,
-      number=1, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
+      number=1, type=14, cpp_type=8, label=1,
+      has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
@@ -312,9 +328,9 @@ _GETSTATUSRESPONSE_MASTERNODE = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='sync_status', full_name='org.dash.platform.dapi.v0.GetStatusResponse.Masternode.sync_status', index=4,
-      number=5, type=14, cpp_type=8, label=1,
-      has_default_value=False, default_value=0,
+      name='sync_progress', full_name='org.dash.platform.dapi.v0.GetStatusResponse.Masternode.sync_progress', index=4,
+      number=5, type=1, cpp_type=5, label=1,
+      has_default_value=False, default_value=float(0),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
@@ -323,7 +339,7 @@ _GETSTATUSRESPONSE_MASTERNODE = _descriptor.Descriptor(
   ],
   nested_types=[],
   enum_types=[
-    _GETSTATUSRESPONSE_MASTERNODE_SYNCSTATUS,
+    _GETSTATUSRESPONSE_MASTERNODE_STATUS,
   ],
   options=None,
   is_extendable=False,
@@ -332,7 +348,7 @@ _GETSTATUSRESPONSE_MASTERNODE = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=741,
-  serialized_end=1041,
+  serialized_end=1064,
 )
 
 _GETSTATUSRESPONSE_NETWORK_FEE = _descriptor.Descriptor(
@@ -368,8 +384,8 @@ _GETSTATUSRESPONSE_NETWORK_FEE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1146,
-  serialized_end=1187,
+  serialized_start=1169,
+  serialized_end=1210,
 )
 
 _GETSTATUSRESPONSE_NETWORK = _descriptor.Descriptor(
@@ -405,8 +421,8 @@ _GETSTATUSRESPONSE_NETWORK = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1044,
-  serialized_end=1187,
+  serialized_start=1067,
+  serialized_end=1210,
 )
 
 _GETSTATUSRESPONSE = _descriptor.Descriptor(
@@ -472,7 +488,7 @@ _GETSTATUSRESPONSE = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=62,
-  serialized_end=1251,
+  serialized_end=1272,
 )
 
 
@@ -512,8 +528,8 @@ _GETBLOCKREQUEST = _descriptor.Descriptor(
       name='block', full_name='org.dash.platform.dapi.v0.GetBlockRequest.block',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=1253,
-  serialized_end=1313,
+  serialized_start=1274,
+  serialized_end=1334,
 )
 
 
@@ -543,8 +559,8 @@ _GETBLOCKRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1315,
-  serialized_end=1348,
+  serialized_start=1336,
+  serialized_end=1369,
 )
 
 
@@ -588,8 +604,8 @@ _BROADCASTTRANSACTIONREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1350,
-  serialized_end=1448,
+  serialized_start=1371,
+  serialized_end=1469,
 )
 
 
@@ -619,8 +635,8 @@ _BROADCASTTRANSACTIONRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1450,
-  serialized_end=1504,
+  serialized_start=1471,
+  serialized_end=1525,
 )
 
 
@@ -650,8 +666,8 @@ _GETTRANSACTIONREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1506,
-  serialized_end=1541,
+  serialized_start=1527,
+  serialized_end=1562,
 )
 
 
@@ -681,8 +697,8 @@ _GETTRANSACTIONRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1543,
-  serialized_end=1588,
+  serialized_start=1564,
+  serialized_end=1609,
 )
 
 
@@ -729,8 +745,8 @@ _BLOCKHEADERSWITHCHAINLOCKSREQUEST = _descriptor.Descriptor(
       name='from_block', full_name='org.dash.platform.dapi.v0.BlockHeadersWithChainLocksRequest.from_block',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=1590,
-  serialized_end=1710,
+  serialized_start=1611,
+  serialized_end=1731,
 )
 
 
@@ -770,8 +786,8 @@ _BLOCKHEADERSWITHCHAINLOCKSRESPONSE = _descriptor.Descriptor(
       name='responses', full_name='org.dash.platform.dapi.v0.BlockHeadersWithChainLocksResponse.responses',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=1713,
-  serialized_end=1924,
+  serialized_start=1734,
+  serialized_end=1945,
 )
 
 
@@ -801,8 +817,8 @@ _BLOCKHEADERS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1926,
-  serialized_end=1957,
+  serialized_start=1947,
+  serialized_end=1978,
 )
 
 
@@ -832,8 +848,8 @@ _CHAINLOCKSIGNATUREMESSAGES = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1959,
-  serialized_end=2005,
+  serialized_start=1980,
+  serialized_end=2026,
 )
 
 
@@ -863,8 +879,8 @@ _GETESTIMATEDTRANSACTIONFEEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2007,
-  serialized_end=2058,
+  serialized_start=2028,
+  serialized_end=2079,
 )
 
 
@@ -894,8 +910,8 @@ _GETESTIMATEDTRANSACTIONFEERESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2060,
-  serialized_end=2109,
+  serialized_start=2081,
+  serialized_end=2130,
 )
 
 
@@ -956,8 +972,8 @@ _TRANSACTIONSWITHPROOFSREQUEST = _descriptor.Descriptor(
       name='from_block', full_name='org.dash.platform.dapi.v0.TransactionsWithProofsRequest.from_block',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=2112,
-  serialized_end=2323,
+  serialized_start=2133,
+  serialized_end=2344,
 )
 
 
@@ -1008,8 +1024,8 @@ _BLOOMFILTER = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2325,
-  serialized_end=2410,
+  serialized_start=2346,
+  serialized_end=2431,
 )
 
 
@@ -1056,8 +1072,8 @@ _TRANSACTIONSWITHPROOFSRESPONSE = _descriptor.Descriptor(
       name='responses', full_name='org.dash.platform.dapi.v0.TransactionsWithProofsResponse.responses',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=2413,
-  serialized_end=2648,
+  serialized_start=2434,
+  serialized_end=2669,
 )
 
 
@@ -1087,8 +1103,8 @@ _RAWTRANSACTIONS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2650,
-  serialized_end=2689,
+  serialized_start=2671,
+  serialized_end=2710,
 )
 
 
@@ -1118,16 +1134,16 @@ _INSTANTSENDLOCKMESSAGES = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2691,
-  serialized_end=2734,
+  serialized_start=2712,
+  serialized_end=2755,
 )
 
 _GETSTATUSRESPONSE_VERSION.containing_type = _GETSTATUSRESPONSE
 _GETSTATUSRESPONSE_TIME.containing_type = _GETSTATUSRESPONSE
 _GETSTATUSRESPONSE_CHAIN.containing_type = _GETSTATUSRESPONSE
-_GETSTATUSRESPONSE_MASTERNODE.fields_by_name['sync_status'].enum_type = _GETSTATUSRESPONSE_MASTERNODE_SYNCSTATUS
+_GETSTATUSRESPONSE_MASTERNODE.fields_by_name['status'].enum_type = _GETSTATUSRESPONSE_MASTERNODE_STATUS
 _GETSTATUSRESPONSE_MASTERNODE.containing_type = _GETSTATUSRESPONSE
-_GETSTATUSRESPONSE_MASTERNODE_SYNCSTATUS.containing_type = _GETSTATUSRESPONSE_MASTERNODE
+_GETSTATUSRESPONSE_MASTERNODE_STATUS.containing_type = _GETSTATUSRESPONSE_MASTERNODE
 _GETSTATUSRESPONSE_NETWORK_FEE.containing_type = _GETSTATUSRESPONSE_NETWORK
 _GETSTATUSRESPONSE_NETWORK.fields_by_name['fee'].message_type = _GETSTATUSRESPONSE_NETWORK_FEE
 _GETSTATUSRESPONSE_NETWORK.containing_type = _GETSTATUSRESPONSE
@@ -1385,8 +1401,8 @@ _CORE = _descriptor.ServiceDescriptor(
   file=DESCRIPTOR,
   index=0,
   options=None,
-  serialized_start=2737,
-  serialized_end=3687,
+  serialized_start=2758,
+  serialized_end=3708,
   methods=[
   _descriptor.MethodDescriptor(
     name='getStatus',

--- a/clients/core/v0/python/core_pb2.py
+++ b/clients/core/v0/python/core_pb2.py
@@ -19,7 +19,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='core.proto',
   package='org.dash.platform.dapi.v0',
   syntax='proto3',
-  serialized_pb=_b('\n\ncore.proto\x12\x19org.dash.platform.dapi.v0\"\x12\n\x10GetStatusRequest\"\x80\n\n\x11GetStatusResponse\x12\x45\n\x07version\x18\x01 \x01(\x0b\x32\x34.org.dash.platform.dapi.v0.GetStatusResponse.Version\x12?\n\x04time\x18\x02 \x01(\x0b\x32\x31.org.dash.platform.dapi.v0.GetStatusResponse.Time\x12\x43\n\x06status\x18\x03 \x01(\x0e\x32\x33.org.dash.platform.dapi.v0.GetStatusResponse.Status\x12\x15\n\rsync_progress\x18\x04 \x01(\x01\x12\x41\n\x05\x63hain\x18\x05 \x01(\x0b\x32\x32.org.dash.platform.dapi.v0.GetStatusResponse.Chain\x12K\n\nmasternode\x18\x06 \x01(\x0b\x32\x37.org.dash.platform.dapi.v0.GetStatusResponse.Masternode\x12\x45\n\x07network\x18\x07 \x01(\x0b\x32\x34.org.dash.platform.dapi.v0.GetStatusResponse.Network\x1a<\n\x07Version\x12\x10\n\x08protocol\x18\x01 \x01(\r\x12\x10\n\x08software\x18\x02 \x01(\r\x12\r\n\x05\x61gent\x18\x03 \x01(\t\x1a\x33\n\x04Time\x12\x0b\n\x03now\x18\x01 \x01(\r\x12\x0e\n\x06offset\x18\x02 \x01(\x05\x12\x0e\n\x06median\x18\x03 \x01(\r\x1a\xad\x01\n\x05\x43hain\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x15\n\rheaders_count\x18\x02 \x01(\r\x12\x14\n\x0c\x62locks_count\x18\x03 \x01(\r\x12\x17\n\x0f\x62\x65st_block_hash\x18\x04 \x01(\x0c\x12\x12\n\ndifficulty\x18\x05 \x01(\x01\x12\x12\n\nchain_work\x18\x06 \x01(\x0c\x12\x11\n\tis_synced\x18\x07 \x01(\x08\x12\x15\n\rsync_progress\x18\x08 \x01(\x01\x1a\xc4\x02\n\nMasternode\x12N\n\x06status\x18\x01 \x01(\x0e\x32>.org.dash.platform.dapi.v0.GetStatusResponse.Masternode.Status\x12\x13\n\x0bpro_tx_hash\x18\x02 \x01(\x0c\x12\x14\n\x0cpose_penalty\x18\x03 \x01(\r\x12\x11\n\tis_synced\x18\x04 \x01(\x08\x12\x15\n\rsync_progress\x18\x05 \x01(\x01\"\x90\x01\n\x06Status\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x15\n\x11WAITING_FOR_PROTX\x10\x01\x12\x0f\n\x0bPOSE_BANNED\x10\x02\x12\x0b\n\x07REMOVED\x10\x03\x12\x18\n\x14OPERATOR_KEY_CHANGED\x10\x04\x12\x14\n\x10PROTX_IP_CHANGED\x10\x05\x12\t\n\x05READY\x10\x06\x12\t\n\x05\x45RROR\x10\x07\x1a)\n\x03\x46\x65\x65\x12\r\n\x05relay\x18\x01 \x01(\x01\x12\x13\n\x0bincremental\x18\x02 \x01(\x01\x1a]\n\x07Network\x12\x13\n\x0bpeers_count\x18\x01 \x01(\r\x12=\n\x03\x66\x65\x65\x18\x02 \x01(\x0b\x32\x30.org.dash.platform.dapi.v0.GetStatusResponse.Fee\"<\n\x06Status\x12\x0f\n\x0bNOT_STARTED\x10\x00\x12\x0b\n\x07SYNCING\x10\x01\x12\t\n\x05READY\x10\x02\x12\t\n\x05\x45RROR\x10\x03\"<\n\x0fGetBlockRequest\x12\x10\n\x06height\x18\x01 \x01(\rH\x00\x12\x0e\n\x04hash\x18\x02 \x01(\tH\x00\x42\x07\n\x05\x62lock\"!\n\x10GetBlockResponse\x12\r\n\x05\x62lock\x18\x01 \x01(\x0c\"b\n\x1b\x42roadcastTransactionRequest\x12\x13\n\x0btransaction\x18\x01 \x01(\x0c\x12\x17\n\x0f\x61llow_high_fees\x18\x02 \x01(\x08\x12\x15\n\rbypass_limits\x18\x03 \x01(\x08\"6\n\x1c\x42roadcastTransactionResponse\x12\x16\n\x0etransaction_id\x18\x01 \x01(\t\"#\n\x15GetTransactionRequest\x12\n\n\x02id\x18\x01 \x01(\t\"-\n\x16GetTransactionResponse\x12\x13\n\x0btransaction\x18\x01 \x01(\x0c\"x\n!BlockHeadersWithChainLocksRequest\x12\x19\n\x0f\x66rom_block_hash\x18\x01 \x01(\x0cH\x00\x12\x1b\n\x11\x66rom_block_height\x18\x02 \x01(\rH\x00\x12\r\n\x05\x63ount\x18\x03 \x01(\rB\x0c\n\nfrom_block\"\xd3\x01\n\"BlockHeadersWithChainLocksResponse\x12@\n\rblock_headers\x18\x01 \x01(\x0b\x32\'.org.dash.platform.dapi.v0.BlockHeadersH\x00\x12^\n\x1d\x63hain_lock_signature_messages\x18\x02 \x01(\x0b\x32\x35.org.dash.platform.dapi.v0.ChainLockSignatureMessagesH\x00\x42\x0b\n\tresponses\"\x1f\n\x0c\x42lockHeaders\x12\x0f\n\x07headers\x18\x01 \x03(\x0c\".\n\x1a\x43hainLockSignatureMessages\x12\x10\n\x08messages\x18\x01 \x03(\x0c\"3\n!GetEstimatedTransactionFeeRequest\x12\x0e\n\x06\x62locks\x18\x01 \x01(\r\"1\n\"GetEstimatedTransactionFeeResponse\x12\x0b\n\x03\x66\x65\x65\x18\x01 \x01(\x01\"\xd3\x01\n\x1dTransactionsWithProofsRequest\x12<\n\x0c\x62loom_filter\x18\x01 \x01(\x0b\x32&.org.dash.platform.dapi.v0.BloomFilter\x12\x19\n\x0f\x66rom_block_hash\x18\x02 \x01(\x0cH\x00\x12\x1b\n\x11\x66rom_block_height\x18\x03 \x01(\rH\x00\x12\r\n\x05\x63ount\x18\x04 \x01(\r\x12\x1f\n\x17send_transaction_hashes\x18\x05 \x01(\x08\x42\x0c\n\nfrom_block\"U\n\x0b\x42loomFilter\x12\x0e\n\x06v_data\x18\x01 \x01(\x0c\x12\x14\n\x0cn_hash_funcs\x18\x02 \x01(\r\x12\x0f\n\x07n_tweak\x18\x03 \x01(\r\x12\x0f\n\x07n_flags\x18\x04 \x01(\r\"\xeb\x01\n\x1eTransactionsWithProofsResponse\x12\x46\n\x10raw_transactions\x18\x01 \x01(\x0b\x32*.org.dash.platform.dapi.v0.RawTransactionsH\x00\x12X\n\x1ainstant_send_lock_messages\x18\x02 \x01(\x0b\x32\x32.org.dash.platform.dapi.v0.InstantSendLockMessagesH\x00\x12\x1a\n\x10raw_merkle_block\x18\x03 \x01(\x0cH\x00\x42\x0b\n\tresponses\"\'\n\x0fRawTransactions\x12\x14\n\x0ctransactions\x18\x01 \x03(\x0c\"+\n\x17InstantSendLockMessages\x12\x10\n\x08messages\x18\x01 \x03(\x0c\x32\xb6\x07\n\x04\x43ore\x12\x66\n\tgetStatus\x12+.org.dash.platform.dapi.v0.GetStatusRequest\x1a,.org.dash.platform.dapi.v0.GetStatusResponse\x12\x63\n\x08getBlock\x12*.org.dash.platform.dapi.v0.GetBlockRequest\x1a+.org.dash.platform.dapi.v0.GetBlockResponse\x12\x87\x01\n\x14\x62roadcastTransaction\x12\x36.org.dash.platform.dapi.v0.BroadcastTransactionRequest\x1a\x37.org.dash.platform.dapi.v0.BroadcastTransactionResponse\x12u\n\x0egetTransaction\x12\x30.org.dash.platform.dapi.v0.GetTransactionRequest\x1a\x31.org.dash.platform.dapi.v0.GetTransactionResponse\x12\x99\x01\n\x1agetEstimatedTransactionFee\x12<.org.dash.platform.dapi.v0.GetEstimatedTransactionFeeRequest\x1a=.org.dash.platform.dapi.v0.GetEstimatedTransactionFeeResponse\x12\xa6\x01\n%subscribeToBlockHeadersWithChainLocks\x12<.org.dash.platform.dapi.v0.BlockHeadersWithChainLocksRequest\x1a=.org.dash.platform.dapi.v0.BlockHeadersWithChainLocksResponse0\x01\x12\x9a\x01\n!subscribeToTransactionsWithProofs\x12\x38.org.dash.platform.dapi.v0.TransactionsWithProofsRequest\x1a\x39.org.dash.platform.dapi.v0.TransactionsWithProofsResponse0\x01\x62\x06proto3')
+  serialized_pb=_b('\n\ncore.proto\x12\x19org.dash.platform.dapi.v0\"\x12\n\x10GetStatusRequest\"\x8e\n\n\x11GetStatusResponse\x12\x45\n\x07version\x18\x01 \x01(\x0b\x32\x34.org.dash.platform.dapi.v0.GetStatusResponse.Version\x12?\n\x04time\x18\x02 \x01(\x0b\x32\x31.org.dash.platform.dapi.v0.GetStatusResponse.Time\x12\x43\n\x06status\x18\x03 \x01(\x0e\x32\x33.org.dash.platform.dapi.v0.GetStatusResponse.Status\x12\x15\n\rsync_progress\x18\x04 \x01(\x01\x12\x41\n\x05\x63hain\x18\x05 \x01(\x0b\x32\x32.org.dash.platform.dapi.v0.GetStatusResponse.Chain\x12K\n\nmasternode\x18\x06 \x01(\x0b\x32\x37.org.dash.platform.dapi.v0.GetStatusResponse.Masternode\x12\x45\n\x07network\x18\x07 \x01(\x0b\x32\x34.org.dash.platform.dapi.v0.GetStatusResponse.Network\x1a<\n\x07Version\x12\x10\n\x08protocol\x18\x01 \x01(\r\x12\x10\n\x08software\x18\x02 \x01(\r\x12\r\n\x05\x61gent\x18\x03 \x01(\t\x1a\x33\n\x04Time\x12\x0b\n\x03now\x18\x01 \x01(\r\x12\x0e\n\x06offset\x18\x02 \x01(\x05\x12\x0e\n\x06median\x18\x03 \x01(\r\x1a\xad\x01\n\x05\x43hain\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x15\n\rheaders_count\x18\x02 \x01(\r\x12\x14\n\x0c\x62locks_count\x18\x03 \x01(\r\x12\x17\n\x0f\x62\x65st_block_hash\x18\x04 \x01(\x0c\x12\x12\n\ndifficulty\x18\x05 \x01(\x01\x12\x12\n\nchain_work\x18\x06 \x01(\x0c\x12\x11\n\tis_synced\x18\x07 \x01(\x08\x12\x15\n\rsync_progress\x18\x08 \x01(\x01\x1a\xc4\x02\n\nMasternode\x12N\n\x06status\x18\x01 \x01(\x0e\x32>.org.dash.platform.dapi.v0.GetStatusResponse.Masternode.Status\x12\x13\n\x0bpro_tx_hash\x18\x02 \x01(\x0c\x12\x14\n\x0cpose_penalty\x18\x03 \x01(\r\x12\x11\n\tis_synced\x18\x04 \x01(\x08\x12\x15\n\rsync_progress\x18\x05 \x01(\x01\"\x90\x01\n\x06Status\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x15\n\x11WAITING_FOR_PROTX\x10\x01\x12\x0f\n\x0bPOSE_BANNED\x10\x02\x12\x0b\n\x07REMOVED\x10\x03\x12\x18\n\x14OPERATOR_KEY_CHANGED\x10\x04\x12\x14\n\x10PROTX_IP_CHANGED\x10\x05\x12\t\n\x05READY\x10\x06\x12\t\n\x05\x45RROR\x10\x07\x1a\x30\n\nNetworkFee\x12\r\n\x05relay\x18\x01 \x01(\x01\x12\x13\n\x0bincremental\x18\x02 \x01(\x01\x1a\x64\n\x07Network\x12\x13\n\x0bpeers_count\x18\x01 \x01(\r\x12\x44\n\x03\x66\x65\x65\x18\x02 \x01(\x0b\x32\x37.org.dash.platform.dapi.v0.GetStatusResponse.NetworkFee\"<\n\x06Status\x12\x0f\n\x0bNOT_STARTED\x10\x00\x12\x0b\n\x07SYNCING\x10\x01\x12\t\n\x05READY\x10\x02\x12\t\n\x05\x45RROR\x10\x03\"<\n\x0fGetBlockRequest\x12\x10\n\x06height\x18\x01 \x01(\rH\x00\x12\x0e\n\x04hash\x18\x02 \x01(\tH\x00\x42\x07\n\x05\x62lock\"!\n\x10GetBlockResponse\x12\r\n\x05\x62lock\x18\x01 \x01(\x0c\"b\n\x1b\x42roadcastTransactionRequest\x12\x13\n\x0btransaction\x18\x01 \x01(\x0c\x12\x17\n\x0f\x61llow_high_fees\x18\x02 \x01(\x08\x12\x15\n\rbypass_limits\x18\x03 \x01(\x08\"6\n\x1c\x42roadcastTransactionResponse\x12\x16\n\x0etransaction_id\x18\x01 \x01(\t\"#\n\x15GetTransactionRequest\x12\n\n\x02id\x18\x01 \x01(\t\"-\n\x16GetTransactionResponse\x12\x13\n\x0btransaction\x18\x01 \x01(\x0c\"x\n!BlockHeadersWithChainLocksRequest\x12\x19\n\x0f\x66rom_block_hash\x18\x01 \x01(\x0cH\x00\x12\x1b\n\x11\x66rom_block_height\x18\x02 \x01(\rH\x00\x12\r\n\x05\x63ount\x18\x03 \x01(\rB\x0c\n\nfrom_block\"\xd3\x01\n\"BlockHeadersWithChainLocksResponse\x12@\n\rblock_headers\x18\x01 \x01(\x0b\x32\'.org.dash.platform.dapi.v0.BlockHeadersH\x00\x12^\n\x1d\x63hain_lock_signature_messages\x18\x02 \x01(\x0b\x32\x35.org.dash.platform.dapi.v0.ChainLockSignatureMessagesH\x00\x42\x0b\n\tresponses\"\x1f\n\x0c\x42lockHeaders\x12\x0f\n\x07headers\x18\x01 \x03(\x0c\".\n\x1a\x43hainLockSignatureMessages\x12\x10\n\x08messages\x18\x01 \x03(\x0c\"3\n!GetEstimatedTransactionFeeRequest\x12\x0e\n\x06\x62locks\x18\x01 \x01(\r\"1\n\"GetEstimatedTransactionFeeResponse\x12\x0b\n\x03\x66\x65\x65\x18\x01 \x01(\x01\"\xd3\x01\n\x1dTransactionsWithProofsRequest\x12<\n\x0c\x62loom_filter\x18\x01 \x01(\x0b\x32&.org.dash.platform.dapi.v0.BloomFilter\x12\x19\n\x0f\x66rom_block_hash\x18\x02 \x01(\x0cH\x00\x12\x1b\n\x11\x66rom_block_height\x18\x03 \x01(\rH\x00\x12\r\n\x05\x63ount\x18\x04 \x01(\r\x12\x1f\n\x17send_transaction_hashes\x18\x05 \x01(\x08\x42\x0c\n\nfrom_block\"U\n\x0b\x42loomFilter\x12\x0e\n\x06v_data\x18\x01 \x01(\x0c\x12\x14\n\x0cn_hash_funcs\x18\x02 \x01(\r\x12\x0f\n\x07n_tweak\x18\x03 \x01(\r\x12\x0f\n\x07n_flags\x18\x04 \x01(\r\"\xeb\x01\n\x1eTransactionsWithProofsResponse\x12\x46\n\x10raw_transactions\x18\x01 \x01(\x0b\x32*.org.dash.platform.dapi.v0.RawTransactionsH\x00\x12X\n\x1ainstant_send_lock_messages\x18\x02 \x01(\x0b\x32\x32.org.dash.platform.dapi.v0.InstantSendLockMessagesH\x00\x12\x1a\n\x10raw_merkle_block\x18\x03 \x01(\x0cH\x00\x42\x0b\n\tresponses\"\'\n\x0fRawTransactions\x12\x14\n\x0ctransactions\x18\x01 \x03(\x0c\"+\n\x17InstantSendLockMessages\x12\x10\n\x08messages\x18\x01 \x03(\x0c\x32\xb6\x07\n\x04\x43ore\x12\x66\n\tgetStatus\x12+.org.dash.platform.dapi.v0.GetStatusRequest\x1a,.org.dash.platform.dapi.v0.GetStatusResponse\x12\x63\n\x08getBlock\x12*.org.dash.platform.dapi.v0.GetBlockRequest\x1a+.org.dash.platform.dapi.v0.GetBlockResponse\x12\x87\x01\n\x14\x62roadcastTransaction\x12\x36.org.dash.platform.dapi.v0.BroadcastTransactionRequest\x1a\x37.org.dash.platform.dapi.v0.BroadcastTransactionResponse\x12u\n\x0egetTransaction\x12\x30.org.dash.platform.dapi.v0.GetTransactionRequest\x1a\x31.org.dash.platform.dapi.v0.GetTransactionResponse\x12\x99\x01\n\x1agetEstimatedTransactionFee\x12<.org.dash.platform.dapi.v0.GetEstimatedTransactionFeeRequest\x1a=.org.dash.platform.dapi.v0.GetEstimatedTransactionFeeResponse\x12\xa6\x01\n%subscribeToBlockHeadersWithChainLocks\x12<.org.dash.platform.dapi.v0.BlockHeadersWithChainLocksRequest\x1a=.org.dash.platform.dapi.v0.BlockHeadersWithChainLocksResponse0\x01\x12\x9a\x01\n!subscribeToTransactionsWithProofs\x12\x38.org.dash.platform.dapi.v0.TransactionsWithProofsRequest\x1a\x39.org.dash.platform.dapi.v0.TransactionsWithProofsResponse0\x01\x62\x06proto3')
 )
 
 
@@ -95,8 +95,8 @@ _GETSTATUSRESPONSE_STATUS = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=1282,
-  serialized_end=1342,
+  serialized_start=1296,
+  serialized_end=1356,
 )
 _sym_db.RegisterEnumDescriptor(_GETSTATUSRESPONSE_STATUS)
 
@@ -351,22 +351,22 @@ _GETSTATUSRESPONSE_MASTERNODE = _descriptor.Descriptor(
   serialized_end=1142,
 )
 
-_GETSTATUSRESPONSE_FEE = _descriptor.Descriptor(
-  name='Fee',
-  full_name='org.dash.platform.dapi.v0.GetStatusResponse.Fee',
+_GETSTATUSRESPONSE_NETWORKFEE = _descriptor.Descriptor(
+  name='NetworkFee',
+  full_name='org.dash.platform.dapi.v0.GetStatusResponse.NetworkFee',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='relay', full_name='org.dash.platform.dapi.v0.GetStatusResponse.Fee.relay', index=0,
+      name='relay', full_name='org.dash.platform.dapi.v0.GetStatusResponse.NetworkFee.relay', index=0,
       number=1, type=1, cpp_type=5, label=1,
       has_default_value=False, default_value=float(0),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='incremental', full_name='org.dash.platform.dapi.v0.GetStatusResponse.Fee.incremental', index=1,
+      name='incremental', full_name='org.dash.platform.dapi.v0.GetStatusResponse.NetworkFee.incremental', index=1,
       number=2, type=1, cpp_type=5, label=1,
       has_default_value=False, default_value=float(0),
       message_type=None, enum_type=None, containing_type=None,
@@ -385,7 +385,7 @@ _GETSTATUSRESPONSE_FEE = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=1144,
-  serialized_end=1185,
+  serialized_end=1192,
 )
 
 _GETSTATUSRESPONSE_NETWORK = _descriptor.Descriptor(
@@ -421,8 +421,8 @@ _GETSTATUSRESPONSE_NETWORK = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1187,
-  serialized_end=1280,
+  serialized_start=1194,
+  serialized_end=1294,
 )
 
 _GETSTATUSRESPONSE = _descriptor.Descriptor(
@@ -484,7 +484,7 @@ _GETSTATUSRESPONSE = _descriptor.Descriptor(
   ],
   extensions=[
   ],
-  nested_types=[_GETSTATUSRESPONSE_VERSION, _GETSTATUSRESPONSE_TIME, _GETSTATUSRESPONSE_CHAIN, _GETSTATUSRESPONSE_MASTERNODE, _GETSTATUSRESPONSE_FEE, _GETSTATUSRESPONSE_NETWORK, ],
+  nested_types=[_GETSTATUSRESPONSE_VERSION, _GETSTATUSRESPONSE_TIME, _GETSTATUSRESPONSE_CHAIN, _GETSTATUSRESPONSE_MASTERNODE, _GETSTATUSRESPONSE_NETWORKFEE, _GETSTATUSRESPONSE_NETWORK, ],
   enum_types=[
     _GETSTATUSRESPONSE_STATUS,
   ],
@@ -495,7 +495,7 @@ _GETSTATUSRESPONSE = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=62,
-  serialized_end=1342,
+  serialized_end=1356,
 )
 
 
@@ -535,8 +535,8 @@ _GETBLOCKREQUEST = _descriptor.Descriptor(
       name='block', full_name='org.dash.platform.dapi.v0.GetBlockRequest.block',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=1344,
-  serialized_end=1404,
+  serialized_start=1358,
+  serialized_end=1418,
 )
 
 
@@ -566,8 +566,8 @@ _GETBLOCKRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1406,
-  serialized_end=1439,
+  serialized_start=1420,
+  serialized_end=1453,
 )
 
 
@@ -611,8 +611,8 @@ _BROADCASTTRANSACTIONREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1441,
-  serialized_end=1539,
+  serialized_start=1455,
+  serialized_end=1553,
 )
 
 
@@ -642,8 +642,8 @@ _BROADCASTTRANSACTIONRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1541,
-  serialized_end=1595,
+  serialized_start=1555,
+  serialized_end=1609,
 )
 
 
@@ -673,8 +673,8 @@ _GETTRANSACTIONREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1597,
-  serialized_end=1632,
+  serialized_start=1611,
+  serialized_end=1646,
 )
 
 
@@ -704,8 +704,8 @@ _GETTRANSACTIONRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1634,
-  serialized_end=1679,
+  serialized_start=1648,
+  serialized_end=1693,
 )
 
 
@@ -752,8 +752,8 @@ _BLOCKHEADERSWITHCHAINLOCKSREQUEST = _descriptor.Descriptor(
       name='from_block', full_name='org.dash.platform.dapi.v0.BlockHeadersWithChainLocksRequest.from_block',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=1681,
-  serialized_end=1801,
+  serialized_start=1695,
+  serialized_end=1815,
 )
 
 
@@ -793,8 +793,8 @@ _BLOCKHEADERSWITHCHAINLOCKSRESPONSE = _descriptor.Descriptor(
       name='responses', full_name='org.dash.platform.dapi.v0.BlockHeadersWithChainLocksResponse.responses',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=1804,
-  serialized_end=2015,
+  serialized_start=1818,
+  serialized_end=2029,
 )
 
 
@@ -824,8 +824,8 @@ _BLOCKHEADERS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2017,
-  serialized_end=2048,
+  serialized_start=2031,
+  serialized_end=2062,
 )
 
 
@@ -855,8 +855,8 @@ _CHAINLOCKSIGNATUREMESSAGES = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2050,
-  serialized_end=2096,
+  serialized_start=2064,
+  serialized_end=2110,
 )
 
 
@@ -886,8 +886,8 @@ _GETESTIMATEDTRANSACTIONFEEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2098,
-  serialized_end=2149,
+  serialized_start=2112,
+  serialized_end=2163,
 )
 
 
@@ -917,8 +917,8 @@ _GETESTIMATEDTRANSACTIONFEERESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2151,
-  serialized_end=2200,
+  serialized_start=2165,
+  serialized_end=2214,
 )
 
 
@@ -979,8 +979,8 @@ _TRANSACTIONSWITHPROOFSREQUEST = _descriptor.Descriptor(
       name='from_block', full_name='org.dash.platform.dapi.v0.TransactionsWithProofsRequest.from_block',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=2203,
-  serialized_end=2414,
+  serialized_start=2217,
+  serialized_end=2428,
 )
 
 
@@ -1031,8 +1031,8 @@ _BLOOMFILTER = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2416,
-  serialized_end=2501,
+  serialized_start=2430,
+  serialized_end=2515,
 )
 
 
@@ -1079,8 +1079,8 @@ _TRANSACTIONSWITHPROOFSRESPONSE = _descriptor.Descriptor(
       name='responses', full_name='org.dash.platform.dapi.v0.TransactionsWithProofsResponse.responses',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=2504,
-  serialized_end=2739,
+  serialized_start=2518,
+  serialized_end=2753,
 )
 
 
@@ -1110,8 +1110,8 @@ _RAWTRANSACTIONS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2741,
-  serialized_end=2780,
+  serialized_start=2755,
+  serialized_end=2794,
 )
 
 
@@ -1141,8 +1141,8 @@ _INSTANTSENDLOCKMESSAGES = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2782,
-  serialized_end=2825,
+  serialized_start=2796,
+  serialized_end=2839,
 )
 
 _GETSTATUSRESPONSE_VERSION.containing_type = _GETSTATUSRESPONSE
@@ -1151,8 +1151,8 @@ _GETSTATUSRESPONSE_CHAIN.containing_type = _GETSTATUSRESPONSE
 _GETSTATUSRESPONSE_MASTERNODE.fields_by_name['status'].enum_type = _GETSTATUSRESPONSE_MASTERNODE_STATUS
 _GETSTATUSRESPONSE_MASTERNODE.containing_type = _GETSTATUSRESPONSE
 _GETSTATUSRESPONSE_MASTERNODE_STATUS.containing_type = _GETSTATUSRESPONSE_MASTERNODE
-_GETSTATUSRESPONSE_FEE.containing_type = _GETSTATUSRESPONSE
-_GETSTATUSRESPONSE_NETWORK.fields_by_name['fee'].message_type = _GETSTATUSRESPONSE_FEE
+_GETSTATUSRESPONSE_NETWORKFEE.containing_type = _GETSTATUSRESPONSE
+_GETSTATUSRESPONSE_NETWORK.fields_by_name['fee'].message_type = _GETSTATUSRESPONSE_NETWORKFEE
 _GETSTATUSRESPONSE_NETWORK.containing_type = _GETSTATUSRESPONSE
 _GETSTATUSRESPONSE.fields_by_name['version'].message_type = _GETSTATUSRESPONSE_VERSION
 _GETSTATUSRESPONSE.fields_by_name['time'].message_type = _GETSTATUSRESPONSE_TIME
@@ -1257,10 +1257,10 @@ GetStatusResponse = _reflection.GeneratedProtocolMessageType('GetStatusResponse'
     ))
   ,
 
-  Fee = _reflection.GeneratedProtocolMessageType('Fee', (_message.Message,), dict(
-    DESCRIPTOR = _GETSTATUSRESPONSE_FEE,
+  NetworkFee = _reflection.GeneratedProtocolMessageType('NetworkFee', (_message.Message,), dict(
+    DESCRIPTOR = _GETSTATUSRESPONSE_NETWORKFEE,
     __module__ = 'core_pb2'
-    # @@protoc_insertion_point(class_scope:org.dash.platform.dapi.v0.GetStatusResponse.Fee)
+    # @@protoc_insertion_point(class_scope:org.dash.platform.dapi.v0.GetStatusResponse.NetworkFee)
     ))
   ,
 
@@ -1279,7 +1279,7 @@ _sym_db.RegisterMessage(GetStatusResponse.Version)
 _sym_db.RegisterMessage(GetStatusResponse.Time)
 _sym_db.RegisterMessage(GetStatusResponse.Chain)
 _sym_db.RegisterMessage(GetStatusResponse.Masternode)
-_sym_db.RegisterMessage(GetStatusResponse.Fee)
+_sym_db.RegisterMessage(GetStatusResponse.NetworkFee)
 _sym_db.RegisterMessage(GetStatusResponse.Network)
 
 GetBlockRequest = _reflection.GeneratedProtocolMessageType('GetBlockRequest', (_message.Message,), dict(
@@ -1409,8 +1409,8 @@ _CORE = _descriptor.ServiceDescriptor(
   file=DESCRIPTOR,
   index=0,
   options=None,
-  serialized_start=2828,
-  serialized_end=3778,
+  serialized_start=2842,
+  serialized_end=3792,
   methods=[
   _descriptor.MethodDescriptor(
     name='getStatus',

--- a/clients/core/v0/python/core_pb2.py
+++ b/clients/core/v0/python/core_pb2.py
@@ -19,14 +19,14 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='core.proto',
   package='org.dash.platform.dapi.v0',
   syntax='proto3',
-  serialized_pb=_b('\n\ncore.proto\x12\x19org.dash.platform.dapi.v0\"\x12\n\x10GetStatusRequest\"\xba\t\n\x11GetStatusResponse\x12\x45\n\x07version\x18\x01 \x01(\x0b\x32\x34.org.dash.platform.dapi.v0.GetStatusResponse.Version\x12?\n\x04time\x18\x02 \x01(\x0b\x32\x31.org.dash.platform.dapi.v0.GetStatusResponse.Time\x12\x43\n\x06status\x18\x03 \x01(\x0e\x32\x33.org.dash.platform.dapi.v0.GetStatusResponse.Status\x12\x15\n\rsync_progress\x18\x04 \x01(\x01\x12\x41\n\x05\x63hain\x18\x05 \x01(\x0b\x32\x32.org.dash.platform.dapi.v0.GetStatusResponse.Chain\x12\x45\n\x07network\x18\x06 \x01(\x0b\x32\x34.org.dash.platform.dapi.v0.GetStatusResponse.Network\x1a<\n\x07Version\x12\x10\n\x08protocol\x18\x01 \x01(\r\x12\x10\n\x08software\x18\x02 \x01(\r\x12\r\n\x05\x61gent\x18\x03 \x01(\t\x1a\x33\n\x04Time\x12\x0b\n\x03now\x18\x01 \x01(\r\x12\x0e\n\x06offset\x18\x02 \x01(\x05\x12\x0e\n\x06median\x18\x03 \x01(\r\x1a\xad\x01\n\x05\x43hain\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x15\n\rheaders_count\x18\x02 \x01(\r\x12\x14\n\x0c\x62locks_count\x18\x03 \x01(\r\x12\x17\n\x0f\x62\x65st_block_hash\x18\x04 \x01(\x0c\x12\x12\n\ndifficulty\x18\x05 \x01(\x01\x12\x12\n\nchain_work\x18\x06 \x01(\x0c\x12\x11\n\tis_synced\x18\x07 \x01(\x08\x12\x15\n\rsync_progress\x18\x08 \x01(\x01\x1a\xc3\x02\n\nMasternode\x12N\n\x06status\x18\x01 \x01(\x0e\x32>.org.dash.platform.dapi.v0.GetStatusResponse.Masternode.Status\x12\x13\n\x0bpro_tx_hash\x18\x02 \x01(\x0c\x12\x13\n\x0bposePenalty\x18\x03 \x01(\r\x12\x11\n\tis_synced\x18\x04 \x01(\x08\x12\x15\n\rsync_progress\x18\x05 \x01(\x01\"\x90\x01\n\x06Status\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x15\n\x11WAITING_FOR_PROTX\x10\x01\x12\x0f\n\x0bPOSE_BANNED\x10\x02\x12\x0b\n\x07REMOVED\x10\x03\x12\x18\n\x14OPERATOR_KEY_CHANGED\x10\x04\x12\x14\n\x10PROTX_IP_CHANGED\x10\x05\x12\t\n\x05READY\x10\x06\x12\t\n\x05\x45RROR\x10\x07\x1a\x8f\x01\n\x07Network\x12\x12\n\npeersCount\x18\x01 \x01(\r\x12\x45\n\x03\x66\x65\x65\x18\x02 \x01(\x0b\x32\x38.org.dash.platform.dapi.v0.GetStatusResponse.Network.Fee\x1a)\n\x03\x46\x65\x65\x12\r\n\x05relay\x18\x01 \x01(\x01\x12\x13\n\x0bincremental\x18\x02 \x01(\x01\"<\n\x06Status\x12\x0f\n\x0bNOT_STARTED\x10\x00\x12\x0b\n\x07SYNCING\x10\x01\x12\t\n\x05READY\x10\x02\x12\t\n\x05\x45RROR\x10\x03\"<\n\x0fGetBlockRequest\x12\x10\n\x06height\x18\x01 \x01(\rH\x00\x12\x0e\n\x04hash\x18\x02 \x01(\tH\x00\x42\x07\n\x05\x62lock\"!\n\x10GetBlockResponse\x12\r\n\x05\x62lock\x18\x01 \x01(\x0c\"b\n\x1b\x42roadcastTransactionRequest\x12\x13\n\x0btransaction\x18\x01 \x01(\x0c\x12\x17\n\x0f\x61llow_high_fees\x18\x02 \x01(\x08\x12\x15\n\rbypass_limits\x18\x03 \x01(\x08\"6\n\x1c\x42roadcastTransactionResponse\x12\x16\n\x0etransaction_id\x18\x01 \x01(\t\"#\n\x15GetTransactionRequest\x12\n\n\x02id\x18\x01 \x01(\t\"-\n\x16GetTransactionResponse\x12\x13\n\x0btransaction\x18\x01 \x01(\x0c\"x\n!BlockHeadersWithChainLocksRequest\x12\x19\n\x0f\x66rom_block_hash\x18\x01 \x01(\x0cH\x00\x12\x1b\n\x11\x66rom_block_height\x18\x02 \x01(\rH\x00\x12\r\n\x05\x63ount\x18\x03 \x01(\rB\x0c\n\nfrom_block\"\xd3\x01\n\"BlockHeadersWithChainLocksResponse\x12@\n\rblock_headers\x18\x01 \x01(\x0b\x32\'.org.dash.platform.dapi.v0.BlockHeadersH\x00\x12^\n\x1d\x63hain_lock_signature_messages\x18\x02 \x01(\x0b\x32\x35.org.dash.platform.dapi.v0.ChainLockSignatureMessagesH\x00\x42\x0b\n\tresponses\"\x1f\n\x0c\x42lockHeaders\x12\x0f\n\x07headers\x18\x01 \x03(\x0c\".\n\x1a\x43hainLockSignatureMessages\x12\x10\n\x08messages\x18\x01 \x03(\x0c\"3\n!GetEstimatedTransactionFeeRequest\x12\x0e\n\x06\x62locks\x18\x01 \x01(\r\"1\n\"GetEstimatedTransactionFeeResponse\x12\x0b\n\x03\x66\x65\x65\x18\x01 \x01(\x01\"\xd3\x01\n\x1dTransactionsWithProofsRequest\x12<\n\x0c\x62loom_filter\x18\x01 \x01(\x0b\x32&.org.dash.platform.dapi.v0.BloomFilter\x12\x19\n\x0f\x66rom_block_hash\x18\x02 \x01(\x0cH\x00\x12\x1b\n\x11\x66rom_block_height\x18\x03 \x01(\rH\x00\x12\r\n\x05\x63ount\x18\x04 \x01(\r\x12\x1f\n\x17send_transaction_hashes\x18\x05 \x01(\x08\x42\x0c\n\nfrom_block\"U\n\x0b\x42loomFilter\x12\x0e\n\x06v_data\x18\x01 \x01(\x0c\x12\x14\n\x0cn_hash_funcs\x18\x02 \x01(\r\x12\x0f\n\x07n_tweak\x18\x03 \x01(\r\x12\x0f\n\x07n_flags\x18\x04 \x01(\r\"\xeb\x01\n\x1eTransactionsWithProofsResponse\x12\x46\n\x10raw_transactions\x18\x01 \x01(\x0b\x32*.org.dash.platform.dapi.v0.RawTransactionsH\x00\x12X\n\x1ainstant_send_lock_messages\x18\x02 \x01(\x0b\x32\x32.org.dash.platform.dapi.v0.InstantSendLockMessagesH\x00\x12\x1a\n\x10raw_merkle_block\x18\x03 \x01(\x0cH\x00\x42\x0b\n\tresponses\"\'\n\x0fRawTransactions\x12\x14\n\x0ctransactions\x18\x01 \x03(\x0c\"+\n\x17InstantSendLockMessages\x12\x10\n\x08messages\x18\x01 \x03(\x0c\x32\xb6\x07\n\x04\x43ore\x12\x66\n\tgetStatus\x12+.org.dash.platform.dapi.v0.GetStatusRequest\x1a,.org.dash.platform.dapi.v0.GetStatusResponse\x12\x63\n\x08getBlock\x12*.org.dash.platform.dapi.v0.GetBlockRequest\x1a+.org.dash.platform.dapi.v0.GetBlockResponse\x12\x87\x01\n\x14\x62roadcastTransaction\x12\x36.org.dash.platform.dapi.v0.BroadcastTransactionRequest\x1a\x37.org.dash.platform.dapi.v0.BroadcastTransactionResponse\x12u\n\x0egetTransaction\x12\x30.org.dash.platform.dapi.v0.GetTransactionRequest\x1a\x31.org.dash.platform.dapi.v0.GetTransactionResponse\x12\x99\x01\n\x1agetEstimatedTransactionFee\x12<.org.dash.platform.dapi.v0.GetEstimatedTransactionFeeRequest\x1a=.org.dash.platform.dapi.v0.GetEstimatedTransactionFeeResponse\x12\xa6\x01\n%subscribeToBlockHeadersWithChainLocks\x12<.org.dash.platform.dapi.v0.BlockHeadersWithChainLocksRequest\x1a=.org.dash.platform.dapi.v0.BlockHeadersWithChainLocksResponse0\x01\x12\x9a\x01\n!subscribeToTransactionsWithProofs\x12\x38.org.dash.platform.dapi.v0.TransactionsWithProofsRequest\x1a\x39.org.dash.platform.dapi.v0.TransactionsWithProofsResponse0\x01\x62\x06proto3')
+  serialized_pb=_b('\n\ncore.proto\x12\x19org.dash.platform.dapi.v0\"\x12\n\x10GetStatusRequest\"\xfc\t\n\x11GetStatusResponse\x12\x45\n\x07version\x18\x01 \x01(\x0b\x32\x34.org.dash.platform.dapi.v0.GetStatusResponse.Version\x12?\n\x04time\x18\x02 \x01(\x0b\x32\x31.org.dash.platform.dapi.v0.GetStatusResponse.Time\x12\x43\n\x06status\x18\x03 \x01(\x0e\x32\x33.org.dash.platform.dapi.v0.GetStatusResponse.Status\x12\x15\n\rsync_progress\x18\x04 \x01(\x01\x12\x41\n\x05\x63hain\x18\x05 \x01(\x0b\x32\x32.org.dash.platform.dapi.v0.GetStatusResponse.Chain\x12K\n\nmasternode\x18\x06 \x01(\x0b\x32\x37.org.dash.platform.dapi.v0.GetStatusResponse.Masternode\x12\x45\n\x07network\x18\x07 \x01(\x0b\x32\x34.org.dash.platform.dapi.v0.GetStatusResponse.Network\x1a<\n\x07Version\x12\x10\n\x08protocol\x18\x01 \x01(\r\x12\x10\n\x08software\x18\x02 \x01(\r\x12\r\n\x05\x61gent\x18\x03 \x01(\t\x1a\x33\n\x04Time\x12\x0b\n\x03now\x18\x01 \x01(\r\x12\x0e\n\x06offset\x18\x02 \x01(\x05\x12\x0e\n\x06median\x18\x03 \x01(\r\x1a\xad\x01\n\x05\x43hain\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x15\n\rheaders_count\x18\x02 \x01(\r\x12\x14\n\x0c\x62locks_count\x18\x03 \x01(\r\x12\x17\n\x0f\x62\x65st_block_hash\x18\x04 \x01(\x0c\x12\x12\n\ndifficulty\x18\x05 \x01(\x01\x12\x12\n\nchain_work\x18\x06 \x01(\x0c\x12\x11\n\tis_synced\x18\x07 \x01(\x08\x12\x15\n\rsync_progress\x18\x08 \x01(\x01\x1a\xb7\x02\n\nMasternode\x12\x42\n\x05state\x18\x01 \x01(\x0e\x32\x33.org.dash.platform.dapi.v0.GetStatusResponse.Status\x12\x13\n\x0bpro_tx_hash\x18\x02 \x01(\x0c\x12\x14\n\x0cpose_penalty\x18\x03 \x01(\r\x12\x11\n\tis_synced\x18\x04 \x01(\x08\x12\x15\n\rsync_progress\x18\x05 \x01(\x01\"\x8f\x01\n\x05State\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x15\n\x11WAITING_FOR_PROTX\x10\x01\x12\x0f\n\x0bPOSE_BANNED\x10\x02\x12\x0b\n\x07REMOVED\x10\x03\x12\x18\n\x14OPERATOR_KEY_CHANGED\x10\x04\x12\x14\n\x10PROTX_IP_CHANGED\x10\x05\x12\t\n\x05READY\x10\x06\x12\t\n\x05\x45RROR\x10\x07\x1a\x90\x01\n\x07Network\x12\x13\n\x0bpeers_count\x18\x01 \x01(\r\x12\x45\n\x03\x66\x65\x65\x18\x02 \x01(\x0b\x32\x38.org.dash.platform.dapi.v0.GetStatusResponse.Network.Fee\x1a)\n\x03\x46\x65\x65\x12\r\n\x05relay\x18\x01 \x01(\x01\x12\x13\n\x0bincremental\x18\x02 \x01(\x01\"<\n\x06Status\x12\x0f\n\x0bNOT_STARTED\x10\x00\x12\x0b\n\x07SYNCING\x10\x01\x12\t\n\x05READY\x10\x02\x12\t\n\x05\x45RROR\x10\x03\"<\n\x0fGetBlockRequest\x12\x10\n\x06height\x18\x01 \x01(\rH\x00\x12\x0e\n\x04hash\x18\x02 \x01(\tH\x00\x42\x07\n\x05\x62lock\"!\n\x10GetBlockResponse\x12\r\n\x05\x62lock\x18\x01 \x01(\x0c\"b\n\x1b\x42roadcastTransactionRequest\x12\x13\n\x0btransaction\x18\x01 \x01(\x0c\x12\x17\n\x0f\x61llow_high_fees\x18\x02 \x01(\x08\x12\x15\n\rbypass_limits\x18\x03 \x01(\x08\"6\n\x1c\x42roadcastTransactionResponse\x12\x16\n\x0etransaction_id\x18\x01 \x01(\t\"#\n\x15GetTransactionRequest\x12\n\n\x02id\x18\x01 \x01(\t\"-\n\x16GetTransactionResponse\x12\x13\n\x0btransaction\x18\x01 \x01(\x0c\"x\n!BlockHeadersWithChainLocksRequest\x12\x19\n\x0f\x66rom_block_hash\x18\x01 \x01(\x0cH\x00\x12\x1b\n\x11\x66rom_block_height\x18\x02 \x01(\rH\x00\x12\r\n\x05\x63ount\x18\x03 \x01(\rB\x0c\n\nfrom_block\"\xd3\x01\n\"BlockHeadersWithChainLocksResponse\x12@\n\rblock_headers\x18\x01 \x01(\x0b\x32\'.org.dash.platform.dapi.v0.BlockHeadersH\x00\x12^\n\x1d\x63hain_lock_signature_messages\x18\x02 \x01(\x0b\x32\x35.org.dash.platform.dapi.v0.ChainLockSignatureMessagesH\x00\x42\x0b\n\tresponses\"\x1f\n\x0c\x42lockHeaders\x12\x0f\n\x07headers\x18\x01 \x03(\x0c\".\n\x1a\x43hainLockSignatureMessages\x12\x10\n\x08messages\x18\x01 \x03(\x0c\"3\n!GetEstimatedTransactionFeeRequest\x12\x0e\n\x06\x62locks\x18\x01 \x01(\r\"1\n\"GetEstimatedTransactionFeeResponse\x12\x0b\n\x03\x66\x65\x65\x18\x01 \x01(\x01\"\xd3\x01\n\x1dTransactionsWithProofsRequest\x12<\n\x0c\x62loom_filter\x18\x01 \x01(\x0b\x32&.org.dash.platform.dapi.v0.BloomFilter\x12\x19\n\x0f\x66rom_block_hash\x18\x02 \x01(\x0cH\x00\x12\x1b\n\x11\x66rom_block_height\x18\x03 \x01(\rH\x00\x12\r\n\x05\x63ount\x18\x04 \x01(\r\x12\x1f\n\x17send_transaction_hashes\x18\x05 \x01(\x08\x42\x0c\n\nfrom_block\"U\n\x0b\x42loomFilter\x12\x0e\n\x06v_data\x18\x01 \x01(\x0c\x12\x14\n\x0cn_hash_funcs\x18\x02 \x01(\r\x12\x0f\n\x07n_tweak\x18\x03 \x01(\r\x12\x0f\n\x07n_flags\x18\x04 \x01(\r\"\xeb\x01\n\x1eTransactionsWithProofsResponse\x12\x46\n\x10raw_transactions\x18\x01 \x01(\x0b\x32*.org.dash.platform.dapi.v0.RawTransactionsH\x00\x12X\n\x1ainstant_send_lock_messages\x18\x02 \x01(\x0b\x32\x32.org.dash.platform.dapi.v0.InstantSendLockMessagesH\x00\x12\x1a\n\x10raw_merkle_block\x18\x03 \x01(\x0cH\x00\x42\x0b\n\tresponses\"\'\n\x0fRawTransactions\x12\x14\n\x0ctransactions\x18\x01 \x03(\x0c\"+\n\x17InstantSendLockMessages\x12\x10\n\x08messages\x18\x01 \x03(\x0c\x32\xb6\x07\n\x04\x43ore\x12\x66\n\tgetStatus\x12+.org.dash.platform.dapi.v0.GetStatusRequest\x1a,.org.dash.platform.dapi.v0.GetStatusResponse\x12\x63\n\x08getBlock\x12*.org.dash.platform.dapi.v0.GetBlockRequest\x1a+.org.dash.platform.dapi.v0.GetBlockResponse\x12\x87\x01\n\x14\x62roadcastTransaction\x12\x36.org.dash.platform.dapi.v0.BroadcastTransactionRequest\x1a\x37.org.dash.platform.dapi.v0.BroadcastTransactionResponse\x12u\n\x0egetTransaction\x12\x30.org.dash.platform.dapi.v0.GetTransactionRequest\x1a\x31.org.dash.platform.dapi.v0.GetTransactionResponse\x12\x99\x01\n\x1agetEstimatedTransactionFee\x12<.org.dash.platform.dapi.v0.GetEstimatedTransactionFeeRequest\x1a=.org.dash.platform.dapi.v0.GetEstimatedTransactionFeeResponse\x12\xa6\x01\n%subscribeToBlockHeadersWithChainLocks\x12<.org.dash.platform.dapi.v0.BlockHeadersWithChainLocksRequest\x1a=.org.dash.platform.dapi.v0.BlockHeadersWithChainLocksResponse0\x01\x12\x9a\x01\n!subscribeToTransactionsWithProofs\x12\x38.org.dash.platform.dapi.v0.TransactionsWithProofsRequest\x1a\x39.org.dash.platform.dapi.v0.TransactionsWithProofsResponse0\x01\x62\x06proto3')
 )
 
 
 
-_GETSTATUSRESPONSE_MASTERNODE_STATUS = _descriptor.EnumDescriptor(
-  name='Status',
-  full_name='org.dash.platform.dapi.v0.GetStatusResponse.Masternode.Status',
+_GETSTATUSRESPONSE_MASTERNODE_STATE = _descriptor.EnumDescriptor(
+  name='State',
+  full_name='org.dash.platform.dapi.v0.GetStatusResponse.Masternode.State',
   filename=None,
   file=DESCRIPTOR,
   values=[
@@ -65,10 +65,10 @@ _GETSTATUSRESPONSE_MASTERNODE_STATUS = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=920,
-  serialized_end=1064,
+  serialized_start=986,
+  serialized_end=1129,
 )
-_sym_db.RegisterEnumDescriptor(_GETSTATUSRESPONSE_MASTERNODE_STATUS)
+_sym_db.RegisterEnumDescriptor(_GETSTATUSRESPONSE_MASTERNODE_STATE)
 
 _GETSTATUSRESPONSE_STATUS = _descriptor.EnumDescriptor(
   name='Status',
@@ -95,8 +95,8 @@ _GETSTATUSRESPONSE_STATUS = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=1212,
-  serialized_end=1272,
+  serialized_start=1278,
+  serialized_end=1338,
 )
 _sym_db.RegisterEnumDescriptor(_GETSTATUSRESPONSE_STATUS)
 
@@ -165,8 +165,8 @@ _GETSTATUSRESPONSE_VERSION = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=449,
-  serialized_end=509,
+  serialized_start=526,
+  serialized_end=586,
 )
 
 _GETSTATUSRESPONSE_TIME = _descriptor.Descriptor(
@@ -209,8 +209,8 @@ _GETSTATUSRESPONSE_TIME = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=511,
-  serialized_end=562,
+  serialized_start=588,
+  serialized_end=639,
 )
 
 _GETSTATUSRESPONSE_CHAIN = _descriptor.Descriptor(
@@ -288,8 +288,8 @@ _GETSTATUSRESPONSE_CHAIN = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=565,
-  serialized_end=738,
+  serialized_start=642,
+  serialized_end=815,
 )
 
 _GETSTATUSRESPONSE_MASTERNODE = _descriptor.Descriptor(
@@ -300,7 +300,7 @@ _GETSTATUSRESPONSE_MASTERNODE = _descriptor.Descriptor(
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='status', full_name='org.dash.platform.dapi.v0.GetStatusResponse.Masternode.status', index=0,
+      name='state', full_name='org.dash.platform.dapi.v0.GetStatusResponse.Masternode.state', index=0,
       number=1, type=14, cpp_type=8, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
@@ -314,7 +314,7 @@ _GETSTATUSRESPONSE_MASTERNODE = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='posePenalty', full_name='org.dash.platform.dapi.v0.GetStatusResponse.Masternode.posePenalty', index=2,
+      name='pose_penalty', full_name='org.dash.platform.dapi.v0.GetStatusResponse.Masternode.pose_penalty', index=2,
       number=3, type=13, cpp_type=3, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
@@ -339,7 +339,7 @@ _GETSTATUSRESPONSE_MASTERNODE = _descriptor.Descriptor(
   ],
   nested_types=[],
   enum_types=[
-    _GETSTATUSRESPONSE_MASTERNODE_STATUS,
+    _GETSTATUSRESPONSE_MASTERNODE_STATE,
   ],
   options=None,
   is_extendable=False,
@@ -347,8 +347,8 @@ _GETSTATUSRESPONSE_MASTERNODE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=741,
-  serialized_end=1064,
+  serialized_start=818,
+  serialized_end=1129,
 )
 
 _GETSTATUSRESPONSE_NETWORK_FEE = _descriptor.Descriptor(
@@ -384,8 +384,8 @@ _GETSTATUSRESPONSE_NETWORK_FEE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1169,
-  serialized_end=1210,
+  serialized_start=1235,
+  serialized_end=1276,
 )
 
 _GETSTATUSRESPONSE_NETWORK = _descriptor.Descriptor(
@@ -396,7 +396,7 @@ _GETSTATUSRESPONSE_NETWORK = _descriptor.Descriptor(
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='peersCount', full_name='org.dash.platform.dapi.v0.GetStatusResponse.Network.peersCount', index=0,
+      name='peers_count', full_name='org.dash.platform.dapi.v0.GetStatusResponse.Network.peers_count', index=0,
       number=1, type=13, cpp_type=3, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
@@ -421,8 +421,8 @@ _GETSTATUSRESPONSE_NETWORK = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1067,
-  serialized_end=1210,
+  serialized_start=1132,
+  serialized_end=1276,
 )
 
 _GETSTATUSRESPONSE = _descriptor.Descriptor(
@@ -468,8 +468,15 @@ _GETSTATUSRESPONSE = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       options=None),
     _descriptor.FieldDescriptor(
-      name='network', full_name='org.dash.platform.dapi.v0.GetStatusResponse.network', index=5,
+      name='masternode', full_name='org.dash.platform.dapi.v0.GetStatusResponse.masternode', index=5,
       number=6, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None),
+    _descriptor.FieldDescriptor(
+      name='network', full_name='org.dash.platform.dapi.v0.GetStatusResponse.network', index=6,
+      number=7, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
@@ -488,7 +495,7 @@ _GETSTATUSRESPONSE = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=62,
-  serialized_end=1272,
+  serialized_end=1338,
 )
 
 
@@ -528,8 +535,8 @@ _GETBLOCKREQUEST = _descriptor.Descriptor(
       name='block', full_name='org.dash.platform.dapi.v0.GetBlockRequest.block',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=1274,
-  serialized_end=1334,
+  serialized_start=1340,
+  serialized_end=1400,
 )
 
 
@@ -559,8 +566,8 @@ _GETBLOCKRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1336,
-  serialized_end=1369,
+  serialized_start=1402,
+  serialized_end=1435,
 )
 
 
@@ -604,8 +611,8 @@ _BROADCASTTRANSACTIONREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1371,
-  serialized_end=1469,
+  serialized_start=1437,
+  serialized_end=1535,
 )
 
 
@@ -635,8 +642,8 @@ _BROADCASTTRANSACTIONRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1471,
-  serialized_end=1525,
+  serialized_start=1537,
+  serialized_end=1591,
 )
 
 
@@ -666,8 +673,8 @@ _GETTRANSACTIONREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1527,
-  serialized_end=1562,
+  serialized_start=1593,
+  serialized_end=1628,
 )
 
 
@@ -697,8 +704,8 @@ _GETTRANSACTIONRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1564,
-  serialized_end=1609,
+  serialized_start=1630,
+  serialized_end=1675,
 )
 
 
@@ -745,8 +752,8 @@ _BLOCKHEADERSWITHCHAINLOCKSREQUEST = _descriptor.Descriptor(
       name='from_block', full_name='org.dash.platform.dapi.v0.BlockHeadersWithChainLocksRequest.from_block',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=1611,
-  serialized_end=1731,
+  serialized_start=1677,
+  serialized_end=1797,
 )
 
 
@@ -786,8 +793,8 @@ _BLOCKHEADERSWITHCHAINLOCKSRESPONSE = _descriptor.Descriptor(
       name='responses', full_name='org.dash.platform.dapi.v0.BlockHeadersWithChainLocksResponse.responses',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=1734,
-  serialized_end=1945,
+  serialized_start=1800,
+  serialized_end=2011,
 )
 
 
@@ -817,8 +824,8 @@ _BLOCKHEADERS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1947,
-  serialized_end=1978,
+  serialized_start=2013,
+  serialized_end=2044,
 )
 
 
@@ -848,8 +855,8 @@ _CHAINLOCKSIGNATUREMESSAGES = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1980,
-  serialized_end=2026,
+  serialized_start=2046,
+  serialized_end=2092,
 )
 
 
@@ -879,8 +886,8 @@ _GETESTIMATEDTRANSACTIONFEEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2028,
-  serialized_end=2079,
+  serialized_start=2094,
+  serialized_end=2145,
 )
 
 
@@ -910,8 +917,8 @@ _GETESTIMATEDTRANSACTIONFEERESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2081,
-  serialized_end=2130,
+  serialized_start=2147,
+  serialized_end=2196,
 )
 
 
@@ -972,8 +979,8 @@ _TRANSACTIONSWITHPROOFSREQUEST = _descriptor.Descriptor(
       name='from_block', full_name='org.dash.platform.dapi.v0.TransactionsWithProofsRequest.from_block',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=2133,
-  serialized_end=2344,
+  serialized_start=2199,
+  serialized_end=2410,
 )
 
 
@@ -1024,8 +1031,8 @@ _BLOOMFILTER = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2346,
-  serialized_end=2431,
+  serialized_start=2412,
+  serialized_end=2497,
 )
 
 
@@ -1072,8 +1079,8 @@ _TRANSACTIONSWITHPROOFSRESPONSE = _descriptor.Descriptor(
       name='responses', full_name='org.dash.platform.dapi.v0.TransactionsWithProofsResponse.responses',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=2434,
-  serialized_end=2669,
+  serialized_start=2500,
+  serialized_end=2735,
 )
 
 
@@ -1103,8 +1110,8 @@ _RAWTRANSACTIONS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2671,
-  serialized_end=2710,
+  serialized_start=2737,
+  serialized_end=2776,
 )
 
 
@@ -1134,16 +1141,16 @@ _INSTANTSENDLOCKMESSAGES = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2712,
-  serialized_end=2755,
+  serialized_start=2778,
+  serialized_end=2821,
 )
 
 _GETSTATUSRESPONSE_VERSION.containing_type = _GETSTATUSRESPONSE
 _GETSTATUSRESPONSE_TIME.containing_type = _GETSTATUSRESPONSE
 _GETSTATUSRESPONSE_CHAIN.containing_type = _GETSTATUSRESPONSE
-_GETSTATUSRESPONSE_MASTERNODE.fields_by_name['status'].enum_type = _GETSTATUSRESPONSE_MASTERNODE_STATUS
+_GETSTATUSRESPONSE_MASTERNODE.fields_by_name['state'].enum_type = _GETSTATUSRESPONSE_STATUS
 _GETSTATUSRESPONSE_MASTERNODE.containing_type = _GETSTATUSRESPONSE
-_GETSTATUSRESPONSE_MASTERNODE_STATUS.containing_type = _GETSTATUSRESPONSE_MASTERNODE
+_GETSTATUSRESPONSE_MASTERNODE_STATE.containing_type = _GETSTATUSRESPONSE_MASTERNODE
 _GETSTATUSRESPONSE_NETWORK_FEE.containing_type = _GETSTATUSRESPONSE_NETWORK
 _GETSTATUSRESPONSE_NETWORK.fields_by_name['fee'].message_type = _GETSTATUSRESPONSE_NETWORK_FEE
 _GETSTATUSRESPONSE_NETWORK.containing_type = _GETSTATUSRESPONSE
@@ -1151,6 +1158,7 @@ _GETSTATUSRESPONSE.fields_by_name['version'].message_type = _GETSTATUSRESPONSE_V
 _GETSTATUSRESPONSE.fields_by_name['time'].message_type = _GETSTATUSRESPONSE_TIME
 _GETSTATUSRESPONSE.fields_by_name['status'].enum_type = _GETSTATUSRESPONSE_STATUS
 _GETSTATUSRESPONSE.fields_by_name['chain'].message_type = _GETSTATUSRESPONSE_CHAIN
+_GETSTATUSRESPONSE.fields_by_name['masternode'].message_type = _GETSTATUSRESPONSE_MASTERNODE
 _GETSTATUSRESPONSE.fields_by_name['network'].message_type = _GETSTATUSRESPONSE_NETWORK
 _GETSTATUSRESPONSE_STATUS.containing_type = _GETSTATUSRESPONSE
 _GETBLOCKREQUEST.oneofs_by_name['block'].fields.append(
@@ -1401,8 +1409,8 @@ _CORE = _descriptor.ServiceDescriptor(
   file=DESCRIPTOR,
   index=0,
   options=None,
-  serialized_start=2758,
-  serialized_end=3708,
+  serialized_start=2824,
+  serialized_end=3774,
   methods=[
   _descriptor.MethodDescriptor(
     name='getStatus',

--- a/protos/core/v0/core.proto
+++ b/protos/core/v0/core.proto
@@ -66,12 +66,12 @@ message GetStatusResponse {
     double sync_progress = 5;
   }
 
-  message Network {
-    message Fee {
-      double relay = 1;
-      double incremental = 2;
-    }
+  message Fee {
+    double relay = 1;
+    double incremental = 2;
+  }
 
+  message Network {
     uint32 peers_count = 1;
     Fee fee = 2;
   }

--- a/protos/core/v0/core.proto
+++ b/protos/core/v0/core.proto
@@ -66,14 +66,14 @@ message GetStatusResponse {
     double sync_progress = 5;
   }
 
-  message Fee {
+  message NetworkFee {
     double relay = 1;
     double incremental = 2;
   }
 
   message Network {
     uint32 peers_count = 1;
-    Fee fee = 2;
+    NetworkFee fee = 2;
   }
 
   Version version = 1;

--- a/protos/core/v0/core.proto
+++ b/protos/core/v0/core.proto
@@ -48,7 +48,7 @@ message GetStatusResponse {
   }
 
   message Masternode {
-    enum Status {
+    enum State {
       UNKNOWN = 0;
       WAITING_FOR_PROTX = 1;
       POSE_BANNED = 2;
@@ -59,7 +59,7 @@ message GetStatusResponse {
       ERROR = 7;
     }
 
-    Status status = 1;
+    Status state = 1;
     bytes pro_tx_hash = 2;
     uint32 pose_penalty = 3;
     bool is_synced = 4;
@@ -81,7 +81,8 @@ message GetStatusResponse {
   Status status = 3;
   double sync_progress = 4;
   Chain chain = 5;
-  Network network = 6;
+  Masternode masternode = 6;
+  Network network = 7;
 }
 
 message GetBlockRequest {

--- a/protos/core/v0/core.proto
+++ b/protos/core/v0/core.proto
@@ -30,10 +30,10 @@ message GetStatusResponse {
   }
 
   enum Status {
-    UNKNOWN = 0;
-    NOT_STARTED = 1;
-    SYNCING = 2;
-    READY = 3;
+    NOT_STARTED = 0;
+    SYNCING = 1;
+    READY = 2;
+    ERROR = 3;
   }
 
   message Chain {
@@ -48,18 +48,22 @@ message GetStatusResponse {
   }
 
   message Masternode {
-    enum SyncStatus {
+    enum Status {
       UNKNOWN = 0;
-      MASTERNODE_SYNC_BLOCKCHAIN = 1;
-      MASTERNODE_SYNC_GOVERNANCE = 4;
-      MASTERNODE_SYNC_FINISHED = 999;
+      WAITING_FOR_PROTX = 1;
+      POSE_BANNED = 2;
+      REMOVED = 3;
+      OPERATOR_KEY_CHANGED = 4;
+      PROTX_IP_CHANGED = 5;
+      READY = 6;
+      ERROR = 7;
     }
 
-    string status = 1; // TODO: Make it enum?
+    Status status = 1;
     bytes pro_tx_hash = 2;
     uint32 posePenalty = 3;
     bool is_synced = 4;
-    SyncStatus sync_status = 5;
+    double sync_progress = 5;
   }
 
   message Network {

--- a/protos/core/v0/core.proto
+++ b/protos/core/v0/core.proto
@@ -17,17 +17,67 @@ message GetStatusRequest {
 }
 
 message GetStatusResponse {
-  uint32 core_version = 1;
-  uint32 protocol_version = 2;
-  uint32 blocks = 3;
-  uint32 time_offset = 4;
-  uint32 connections = 5;
-  string proxy = 6;
-  double difficulty = 7;
-  bool testnet = 8;
-  double relay_fee = 9;
-  string errors = 10;
-  string network = 11;
+  message Version {
+    uint32 protocol = 1;
+    uint32 software = 2;
+    string agent = 3;
+  }
+
+  message Time {
+    uint32 now = 1;
+    int32 offset = 2;
+    uint32 median = 3;
+  }
+
+  enum Status {
+    UNKNOWN = 0;
+    NOT_STARTED = 1;
+    SYNCING = 2;
+    READY = 3;
+  }
+
+  message Chain {
+    string name = 1;
+    uint32 headers_count = 2;
+    uint32 blocks_count = 3;
+    bytes best_block_hash = 4;
+    double difficulty = 5;
+    bytes chain_work = 6;
+    bool is_synced = 7;
+    double sync_progress = 8;
+  }
+
+  message Masternode {
+    enum SyncStatus {
+      UNKNOWN = 0;
+      MASTERNODE_SYNC_BLOCKCHAIN = 1;
+      MASTERNODE_SYNC_GOVERNANCE = 4;
+      MASTERNODE_SYNC_FINISHED = 999;
+    }
+
+    string status = 1; // TODO: Make it enum?
+    bytes pro_tx_hash = 2;
+    uint32 posePenalty = 3;
+    bool is_synced = 4;
+    SyncStatus sync_status = 5;
+  }
+
+  message Network {
+    message Fee {
+      double relay = 1;
+      double incremental = 2;
+    }
+
+    uint32 peersCount = 1;
+    Fee fee = 2;
+  }
+
+  Version version = 1;
+  Time time = 2;
+  Status status = 3;
+  double sync_progress = 4;
+  Chain chain = 5;
+  Network network = 6;
 }
 
 message GetBlockRequest {

--- a/protos/core/v0/core.proto
+++ b/protos/core/v0/core.proto
@@ -61,7 +61,7 @@ message GetStatusResponse {
 
     Status status = 1;
     bytes pro_tx_hash = 2;
-    uint32 posePenalty = 3;
+    uint32 pose_penalty = 3;
     bool is_synced = 4;
     double sync_progress = 5;
   }
@@ -72,7 +72,7 @@ message GetStatusResponse {
       double incremental = 2;
     }
 
-    uint32 peersCount = 1;
+    uint32 peers_count = 1;
     Fee fee = 2;
   }
 

--- a/protos/core/v0/core.proto
+++ b/protos/core/v0/core.proto
@@ -48,7 +48,7 @@ message GetStatusResponse {
   }
 
   message Masternode {
-    enum State {
+    enum Status {
       UNKNOWN = 0;
       WAITING_FOR_PROTX = 1;
       POSE_BANNED = 2;
@@ -59,7 +59,7 @@ message GetStatusResponse {
       ERROR = 7;
     }
 
-    Status state = 1;
+    Status status = 1;
     bytes pro_tx_hash = 2;
     uint32 pose_penalty = 3;
     bool is_synced = 4;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented

This pull request implements a new structure for core getStatus response. 

## What was done?
- fea!t: restructured core status response


## How Has This Been Tested?
- embedded tests


## Breaking Changes
- structure of getStatus has changed to the below format : 

```
version: {
      protocol: networkInfo.protocolversion (uint32),
      software: networkInfo.version (uint32),
      agent: networkInfo.subversion (str),
}
time: {
   now: Date.now() (uint32)
   offset: networkInfo.timeoffset (int32),
   median: blockchainInfo.mediantime (uint32),
}
status: enum: not started, syncing, ready (chain.isSynced && masternode.isSynced),
syncProgress:  blockchainInfo.verificationprogress (double),
chain: {
   name: blockchainInfo.chain (str),
   blocksCount: blockchainInfo.blocks (uint32),
   headersCount: blockchainInfo.headers (uint32),
   bestBlockHash: blockchainInfo.bestblockhash (binary),
   difficulty: blockchainInfo.difficulty (double),
   chainWork: blockchainInfo.chainwork (binary),
   isSynced:  mnsync status.isBlockchainSynced (bool),
   syncProgress:  blockchainInfo.verificationprogress (double),
}
masternode: {
   state: "masternode status".state (enum),
   proTxHash: "masternode status".proTxHash (binary),
   posePenalty: "masternode status".dmnState.PoSePenalty (unit32)
   isSynced: mnsync status.isSynced (boolean),
   syncProgress:  mnsync status.AssetId (double)
}
network: {
   peersCount: networkInfo.connections  (unit32),
   fee: {
      relay: networkInfo.relayfee (double)
      incremental: networkInfo.incrementalfee (double)
   }
} 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [X] I have assigned this pull request to a milestone
