### PR TITLE
fix: cannot read properties of undefined (reading 'MethodInfo')

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@dashevo/grpc-common": "^0.5.4",
         "@grpc/grpc-js": "^1.3.6",
         "google-protobuf": "^3.12.2",
-        "grpc-web": "^1.2.0",
+        "grpc-web": "1.2.1",
         "protobufjs": "github:jawid-h/protobuf.js#fix/buffer-conversion"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@dashevo/grpc-common": "^0.5.4",
     "@grpc/grpc-js": "^1.3.6",
     "google-protobuf": "^3.12.2",
-    "grpc-web": "^1.2.0",
+    "grpc-web": "1.2.1",
     "protobufjs": "github:jawid-h/protobuf.js#fix/buffer-conversion"
   },
   "devDependencies": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix for the https://github.com/dashevo/js-dash-sdk/issues/297


## What was done?
<!--- Describe your changes in detail -->
Locked `grpc-web` version to `v1.2.1`


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Set up the local JS project with the `webpack` for browser bundling
- Install `dash` SDK
- Add `import Dash from 'dash'` to the code
- `yarn link` local build of the `@dashevo/dapi-grpc`
- Build a local project with the webpack, run in the browser, and ensure that it does not crash with error provided in https://github.com/dashevo/js-dash-sdk/issues/297


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
